### PR TITLE
feat: 로그인 및 로그아웃 후 리다이렉트, 리프레쉬 추가

### DIFF
--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -1,7 +1,3 @@
-import {NaverLoginInitParams, NaverLoginResponse} from '@/types/Login';
-import {SessionType} from '@/types/Session';
-import {UserType} from '@/types/UserType';
-import {getStorage, setStorage} from '@/utils/storage';
 import {
   getProfile as getKakaoProfile,
   login as kakaoLogin,
@@ -10,6 +6,11 @@ import {
 import NaverLogin from '@react-native-seoul/naver-login';
 import {NativeModules, Platform} from 'react-native';
 import Config from 'react-native-config';
+
+import {NaverLoginInitParams, NaverLoginResponse} from '@/types/Login';
+import {SessionType} from '@/types/Session';
+import {UserType} from '@/types/UserType';
+import {getStorage, setStorage} from '@/utils/storage';
 import apiClient from './ApiClient';
 
 // 네이버 로그인 관련 설정
@@ -171,6 +172,8 @@ export const logout = async (): Promise<boolean> => {
     } else if (storageRes.OAuthProvider === 'NAVER') {
       await NaverLogin.logout();
     }
+
+    await setStorage('session', {});
 
     return true;
   } catch (error) {

--- a/src/components/myPage/Profile.tsx
+++ b/src/components/myPage/Profile.tsx
@@ -1,10 +1,17 @@
+import {useNavigation} from '@react-navigation/native';
+import {StackNavigationProp} from '@react-navigation/stack';
 import React from 'react';
 import {Alert} from 'react-native';
 import {Button, Text} from 'react-native-paper';
-import S from './Profile.style';
+
 import {logout} from '@/apis/Login';
+import {RootStackParamList} from '@/types/StackNavigationType';
+
+import S from './Profile.style';
 
 const Profile = ({name, image}: {name: string; image?: string}) => {
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
+
   return (
     <S.ProfileContainer>
       <S.ProfileImage
@@ -30,8 +37,22 @@ const Profile = ({name, image}: {name: string; image?: string}) => {
               <S.LinkText>프로필</S.LinkText>
             </S.Link>
           </S.LinkContainer>
-          {/* TODO: 로그아웃 */}
-          <Button onPress={() => logout()}>로그아웃</Button>
+          <Button
+            onPress={async () => {
+              const res = await logout();
+              if (res) {
+                Alert.alert('로그아웃 되었습니다.', '', [
+                  {
+                    text: '확인',
+                    onPress: () => {
+                      navigation.navigate('Home', {screen: 'Feed'});
+                    },
+                  },
+                ]);
+              }
+            }}>
+            로그아웃
+          </Button>
         </S.LinkLayout>
       </S.ProfileInfo>
     </S.ProfileContainer>

--- a/src/screens/MyPageScreen/index.tsx
+++ b/src/screens/MyPageScreen/index.tsx
@@ -1,30 +1,31 @@
-import React, {useEffect} from 'react';
+import {StackScreenProps} from '@react-navigation/stack';
+import {useIsFocused} from '@react-navigation/native';
+import React, {useEffect, useState} from 'react';
 
 import {getProfile} from '@/apis/Login';
 import {RootStackParamList} from '@/types/StackNavigationType';
 import {UserType} from '@/types/UserType';
-import {StackScreenProps} from '@react-navigation/stack';
 import NonMemberMyPage from './NonMemberMyPage';
 import UserMyPage from './UserMyPage';
 
 type Props = StackScreenProps<RootStackParamList, 'MyPage'>;
 
 const MyPageScreen = ({navigation}: Props) => {
-  const [profile, setProfile] = React.useState<UserType | null>(null);
+  const [profile, setProfile] = useState<UserType | null>(null);
+
+  const isFocused = useIsFocused();
 
   useEffect(() => {
     const fetchProfile = async () => {
       const res = await getProfile();
 
-      if (!res) {
-        return;
-      }
-
       setProfile(res);
     };
 
-    fetchProfile();
-  }, []);
+    if (isFocused) {
+      fetchProfile();
+    }
+  }, [isFocused]);
 
   if (!profile) {
     return (

--- a/src/screens/RegisterScreen/LoginScreen.tsx
+++ b/src/screens/RegisterScreen/LoginScreen.tsx
@@ -1,16 +1,13 @@
-// import {StackNavigationProp} from '@react-navigation/stack';
-// import {RootStackParamList} from '../../types/StackNavigationType';
+import {NavigationProp, useNavigation} from '@react-navigation/native';
 import React from 'react';
 
 import {login} from '@/apis/Login';
+import {RootStackParamList} from '@/types/StackNavigationType';
 
 import S from './LoginScreen.style';
 
-// type Props = {
-//   navigation: StackNavigationProp<RootStackParamList, 'Register'>;
-// };
-
 const LoginScreen = () => {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   return (
     <S.LoginPageContainer>
       <S.LoginButtonContainer>
@@ -22,12 +19,24 @@ const LoginScreen = () => {
         <S.LoginButtonContainer>
           <S.LoginButtonWrapper>
             {/* TODO: 애플 로그인 적용 시 props로 분기 필요 */}
-            <S.KakaoButton onPress={() => login('KAKAO')}>
+            <S.KakaoButton
+              onPress={async () => {
+                const res = await login('KAKAO');
+                if (res) {
+                  navigation.navigate('Home', {screen: 'Feed'});
+                }
+              }}>
               <S.KakaoButtonText>카카오 로그인 시작하기</S.KakaoButtonText>
             </S.KakaoButton>
           </S.LoginButtonWrapper>
           <S.LoginButtonWrapper>
-            <S.NaverButton onPress={() => login('NAVER')}>
+            <S.NaverButton
+              onPress={async () => {
+                const res = await login('NAVER');
+                if (res) {
+                  navigation.navigate('Home', {screen: 'Feed'});
+                }
+              }}>
               <S.NaverButtonText>네이버 로그인 시작하기</S.NaverButtonText>
             </S.NaverButton>
           </S.LoginButtonWrapper>

--- a/src/types/Session.ts
+++ b/src/types/Session.ts
@@ -5,9 +5,3 @@ export type SessionType = {
   refreshTokenExpiresAt: number;
   OAuthProvider: 'NAVER' | 'KAKAO';
 };
-
-export type StorageType = {
-  session: SessionType;
-};
-
-export type StorageKeyType = keyof StorageType;

--- a/src/types/Storage.ts
+++ b/src/types/Storage.ts
@@ -1,0 +1,7 @@
+import {SessionType} from './Session';
+
+export type StorageType = {
+  session: SessionType;
+};
+
+export type StorageKeyType = keyof StorageType;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,6 +1,6 @@
 import EncryptedStorage from 'react-native-encrypted-storage';
 
-import {StorageKeyType} from '@/types/Session';
+import {StorageKeyType} from '@/types/Storage';
 
 export const setStorage = async <T extends Object>(
   key: StorageKeyType,


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #51

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->


- 로그인 성공 시
  - Home-Feed로 리디렉션합니다.
- 로그아웃 성공 시 
  - `setStorage`를 호출하여 session을 빈 객체로 교체합니다.
  - Home-Feed로 리디렉션합니다.
  - `useIsFocused` 을 이용하여 마이페이지 접근 시 `getProfile`을 호출하도록 합니다.
- `type/**`하위의 Session과 Storage를 분리합니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

`useIsFocused` 대신 리코일 등의 상태관리 라이브러리를 통해서 로그인 세션의 refresh를 컨트롤 하는 게 더 좋을 것 같지만, 일단은 임시 방편으로 이와 같이 구현합니다
