### PR TITLE
feat: 찜 가게 페이지 제작

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,10 @@ yarn-error.log
 
 # react-native-config codegen
 ios/tmp.xcconfig
+
+# Firebase configuration files
+GoogleService-Info.plist
+google-services.json
+
+# iOS entitlements
+ClientApp.entitlements

--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -115,9 +115,9 @@ const signInWithKakao = async (): Promise<SessionType | null> => {
 
     if (response) {
       console.log('카카오 로그인 성공:', response);
-
+      console.log(response.data);
       return {
-        accessToken: token.accessToken,
+        accessToken: response.data.accessToken,
         refreshToken: token.refreshToken,
         accessTokenExpiresAt: new Date(token.accessTokenExpiresAt).getTime(),
         refreshTokenExpiresAt: new Date(token.refreshTokenExpiresAt).getTime(),

--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -115,7 +115,6 @@ const signInWithKakao = async (): Promise<SessionType | null> => {
 
     if (response) {
       console.log('카카오 로그인 성공:', response);
-      console.log(response.data);
       return {
         accessToken: response.data.accessToken,
         refreshToken: token.refreshToken,

--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -116,7 +116,7 @@ const signInWithKakao = async (): Promise<SessionType | null> => {
     if (response) {
       console.log('카카오 로그인 성공:', response);
       return {
-        accessToken: response.data.accessToken,
+        accessToken: token.accessToken,
         refreshToken: token.refreshToken,
         accessTokenExpiresAt: new Date(token.accessTokenExpiresAt).getTime(),
         refreshTokenExpiresAt: new Date(token.refreshTokenExpiresAt).getTime(),

--- a/src/apis/Subscribe.ts
+++ b/src/apis/Subscribe.ts
@@ -1,98 +1,22 @@
 import {SubscribeType} from '@/types/Subscribe';
-// import apiClient from './ApiClient';
+import apiClient from './ApiClient';
 
-// export const getSubscribeList = async (
-//   cursorId: number = 0,
-//   size: number = 10,
-// ): Promise<{
-//   markets: SubscribeType[];
-//   hasNext: boolean;
-// } | null> => {
-//   try {
-//     const res = await apiClient.get<{
-//       markets: SubscribeType[];
-//       hasNext: boolean;
-//     } | null>(`/market/paging?cursorId=${cursorId}&size=${size}`);
-//     return res;
-//   } catch (error) {
-//     console.error('Error Subscribed market list:', error);
-//     return null;
-//   }
-// };
-const dummySubscribeList: SubscribeType[] = [
-  {
-    id: 1,
-    name: '신선 마켓',
-    address: '서울시 중구 메인로 123',
-    specificAddress: 'A동 3층',
-    openAt: '09:00',
-    closeAt: '21:00',
-    products: [
-      {
-        id: 101,
-        name: '사과',
-        image: 'https://legacy.reactjs.org/logo-og.png',
-        originalPrice: 3000,
-        discountPrice: 2500,
-        tags: ['과일', '신선', '유기농'],
-      },
-      {
-        id: 102,
-        name: '바나나',
-        image: 'https://example.com/images/banana.jpg',
-        originalPrice: 2000,
-        discountPrice: 1500,
-        tags: ['과일', '노란색', '수입'],
-      },
-    ],
-  },
-  {
-    id: 2,
-    name: '그린 식품점',
-    address: '서울시 강남구 마켓로 456',
-    specificAddress: '7번 가게',
-    openAt: '08:00',
-    closeAt: '20:00',
-    products: [
-      {
-        id: 201,
-        name: '당근',
-        image: 'https://legacy.reactjs.org/logo-og.png',
-
-        originalPrice: 1500,
-        discountPrice: 1200,
-        tags: ['채소', '유기농', '국내산'],
-      },
-      {
-        id: 202,
-        name: '감자',
-        image: 'https://example.com/images/potato.jpg',
-        originalPrice: 1000,
-        discountPrice: 800,
-        tags: ['채소', '주식', '국내산'],
-      },
-      {
-        id: 203,
-        name: '토마토',
-        image: 'https://example.com/images/tomato.jpg',
-        originalPrice: 2500,
-        discountPrice: 2000,
-        tags: ['과일', '신선', '유기농'],
-      },
-    ],
-  },
-];
-
-export const getSubscribeList = async (): Promise<SubscribeType[] | null> => {
+export const getSubscribeList = async (
+  cursorId: number = 0,
+  size: number = 10,
+): Promise<{
+  markets: SubscribeType[];
+  hasNext: boolean;
+} | null> => {
   try {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        resolve(dummySubscribeList);
-        console.log('fetch');
-      }, 500);
-    });
+    const res = await apiClient.get<{
+      markets: SubscribeType[];
+      hasNext: boolean;
+    } | null>(`/market/like?cursorId=${cursorId}&size=${size}`);
+    console.log(res?.markets);
+    return res;
   } catch (error) {
-    console.error('Error fetching Subscribe List:', error);
+    console.error('Error Subscribed market list:', error);
     return null;
   }
 };

--- a/src/apis/Subscribe.ts
+++ b/src/apis/Subscribe.ts
@@ -1,0 +1,98 @@
+import {SubscribeType} from '@/types/Subscribe';
+// import apiClient from './ApiClient';
+
+// export const getSubscribeList = async (
+//   cursorId: number = 0,
+//   size: number = 10,
+// ): Promise<{
+//   markets: SubscribeType[];
+//   hasNext: boolean;
+// } | null> => {
+//   try {
+//     const res = await apiClient.get<{
+//       markets: SubscribeType[];
+//       hasNext: boolean;
+//     } | null>(`/market/paging?cursorId=${cursorId}&size=${size}`);
+//     return res;
+//   } catch (error) {
+//     console.error('Error Subscribed market list:', error);
+//     return null;
+//   }
+// };
+const dummySubscribeList: SubscribeType[] = [
+  {
+    id: 1,
+    name: '신선 마켓',
+    address: '서울시 중구 메인로 123',
+    specificAddress: 'A동 3층',
+    openAt: '09:00',
+    closeAt: '21:00',
+    products: [
+      {
+        id: 101,
+        name: '사과',
+        image: 'https://legacy.reactjs.org/logo-og.png',
+        originalPrice: 3000,
+        discountPrice: 2500,
+        tags: ['과일', '신선', '유기농'],
+      },
+      {
+        id: 102,
+        name: '바나나',
+        image: 'https://example.com/images/banana.jpg',
+        originalPrice: 2000,
+        discountPrice: 1500,
+        tags: ['과일', '노란색', '수입'],
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: '그린 식품점',
+    address: '서울시 강남구 마켓로 456',
+    specificAddress: '7번 가게',
+    openAt: '08:00',
+    closeAt: '20:00',
+    products: [
+      {
+        id: 201,
+        name: '당근',
+        image: 'https://legacy.reactjs.org/logo-og.png',
+
+        originalPrice: 1500,
+        discountPrice: 1200,
+        tags: ['채소', '유기농', '국내산'],
+      },
+      {
+        id: 202,
+        name: '감자',
+        image: 'https://example.com/images/potato.jpg',
+        originalPrice: 1000,
+        discountPrice: 800,
+        tags: ['채소', '주식', '국내산'],
+      },
+      {
+        id: 203,
+        name: '토마토',
+        image: 'https://example.com/images/tomato.jpg',
+        originalPrice: 2500,
+        discountPrice: 2000,
+        tags: ['과일', '신선', '유기농'],
+      },
+    ],
+  },
+];
+
+export const getSubscribeList = async (): Promise<SubscribeType[] | null> => {
+  try {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve(dummySubscribeList);
+        console.log('fetch');
+      }, 500);
+    });
+  } catch (error) {
+    console.error('Error fetching Subscribe List:', error);
+    return null;
+  }
+};

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -23,6 +23,10 @@ const tabBarData: TabBarComponentType = {
     label: '주문 내역',
     icon: 'https://legacy.reactjs.org/logo-og.png',
   },
+  Subscribe: {
+    label: '찜',
+    icon: 'https://legacy.reactjs.org/logo-og.png',
+  },
 };
 
 // TODO: resolve inline style

--- a/src/components/subscribePage/SubscribeMarketCard.style.tsx
+++ b/src/components/subscribePage/SubscribeMarketCard.style.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/native';
+
+const SubscribeMarketCard = styled.View`
+  display: flex;
+  flex-direction: row;
+  background-color: white;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  width: 100%;
+  height: 120px;
+  align-items: center;
+`;
+
+const MarketInfo = styled.View`
+  display: flex;
+  gap: 4px;
+`;
+
+const MarketNameText = styled.Text`
+  font-family: pretendard;
+  font-weight: bold;
+  font-size: 16px;
+`;
+
+const MarketDescribeText = styled.Text`
+  font-family: pretendard;
+  font-size: 14px;
+  font-weight: 400;
+`;
+
+const thumbnailImage = styled.Image`
+  width: 64px;
+  height: 84px;
+  border-radius: 12px;
+  margin: 0px 16px;
+`;
+
+const S = {
+  SubscribeMarketCard,
+  MarketInfo,
+  MarketNameText,
+  MarketDescribeText,
+  thumbnailImage,
+};
+
+export default S;

--- a/src/components/subscribePage/SubscribeMarketCard.style.tsx
+++ b/src/components/subscribePage/SubscribeMarketCard.style.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/native';
 
-const SubscribeMarketCard = styled.View`
+const SubscribeMarketCard = styled.TouchableOpacity`
   display: flex;
   flex-direction: row;
   background-color: white;

--- a/src/components/subscribePage/SubscribeMarketCard.tsx
+++ b/src/components/subscribePage/SubscribeMarketCard.tsx
@@ -3,23 +3,27 @@ import S from './SubscribeMarketCard.style';
 
 type SubscribeMarketCardProps = {
   name: string;
+  marketid: number;
   address: string;
   specificAddress: string;
   openAt: string;
   closeAt: string;
   thumbnailImage: string;
+  onPress: (marketId: number) => void;
 };
 
 const SubscribeMarketCard = ({
   name,
+  marketid,
   address,
   specificAddress,
   openAt,
   closeAt,
   thumbnailImage,
+  onPress,
 }: SubscribeMarketCardProps) => {
   return (
-    <S.SubscribeMarketCard>
+    <S.SubscribeMarketCard onPress={() => onPress(marketid)}>
       <S.thumbnailImage source={{uri: thumbnailImage}} />
       <S.MarketInfo>
         <S.MarketNameText>{name}</S.MarketNameText>

--- a/src/components/subscribePage/SubscribeMarketCard.tsx
+++ b/src/components/subscribePage/SubscribeMarketCard.tsx
@@ -3,7 +3,7 @@ import S from './SubscribeMarketCard.style';
 
 type SubscribeMarketCardProps = {
   name: string;
-  marketid: number;
+  marketId: number;
   address: string;
   specificAddress: string;
   openAt: string;
@@ -14,7 +14,7 @@ type SubscribeMarketCardProps = {
 
 const SubscribeMarketCard = ({
   name,
-  marketid,
+  marketId,
   address,
   specificAddress,
   openAt,
@@ -23,7 +23,7 @@ const SubscribeMarketCard = ({
   onPress,
 }: SubscribeMarketCardProps) => {
   return (
-    <S.SubscribeMarketCard onPress={() => onPress(marketid)}>
+    <S.SubscribeMarketCard onPress={() => onPress(marketId)}>
       <S.thumbnailImage source={{uri: thumbnailImage}} />
       <S.MarketInfo>
         <S.MarketNameText>{name}</S.MarketNameText>

--- a/src/components/subscribePage/SubscribeMarketCard.tsx
+++ b/src/components/subscribePage/SubscribeMarketCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import S from './SubscribeMarketCard.style';
+
+type SubscribeMarketCardProps = {
+  name: string;
+  address: string;
+  specificAddress: string;
+  openAt: string;
+  closeAt: string;
+  thumbnailImage: string;
+};
+
+const SubscribeMarketCard = ({
+  name,
+  address,
+  specificAddress,
+  openAt,
+  closeAt,
+  thumbnailImage,
+}: SubscribeMarketCardProps) => {
+  return (
+    <S.SubscribeMarketCard>
+      <S.thumbnailImage source={{uri: thumbnailImage}} />
+      <S.MarketInfo>
+        <S.MarketNameText>{name}</S.MarketNameText>
+        <S.MarketDescribeText>
+          가게 주소: {address} {specificAddress}
+        </S.MarketDescribeText>
+        <S.MarketDescribeText>여는 시간: {openAt}</S.MarketDescribeText>
+        <S.MarketDescribeText>닫는 시간: {closeAt}</S.MarketDescribeText>
+      </S.MarketInfo>
+    </S.SubscribeMarketCard>
+  );
+};
+
+export default SubscribeMarketCard;

--- a/src/navigation/HomeNavigator.tsx
+++ b/src/navigation/HomeNavigator.tsx
@@ -19,7 +19,11 @@ const HomeNavigator = () => {
   return (
     <Tab.Navigator tabBar={TabBar}>
       <Tab.Screen name="Feed" options={screenOptions} component={HomeScreen} />
-      <Tab.Screen name="Subscribe" component={SubscribeScreen} />
+      <Tab.Screen
+        name="Subscribe"
+        options={screenOptions}
+        component={SubscribeScreen}
+      />
       <Tab.Screen name="OrderHistory" component={OrderHistoryScreen} />
       <Tab.Screen name="MyPage" component={MyPageScreen} />
 

--- a/src/navigation/HomeNavigator.tsx
+++ b/src/navigation/HomeNavigator.tsx
@@ -6,6 +6,7 @@ import MyPageScreen from '@screens/MyPageScreen';
 import OrderHistoryScreen from '@/screens/OrderHistoryScreen';
 import {HomeStackParamList} from '@/types/StackNavigationType';
 import CartIcon from '@/components/common/CartNavigatorIcon';
+import SubscribeScreen from '@/screens/SubscribeScreen';
 
 const Tab = createBottomTabNavigator<HomeStackParamList>();
 
@@ -18,8 +19,10 @@ const HomeNavigator = () => {
   return (
     <Tab.Navigator tabBar={TabBar}>
       <Tab.Screen name="Feed" options={screenOptions} component={HomeScreen} />
-      <Tab.Screen name="MyPage" component={MyPageScreen} />
+      <Tab.Screen name="Subscribe" component={SubscribeScreen} />
       <Tab.Screen name="OrderHistory" component={OrderHistoryScreen} />
+      <Tab.Screen name="MyPage" component={MyPageScreen} />
+
       {/* <Tab.Screen name="Favorite" component={FavoriteScreen} /> */}
       {/* Add more screens here */}
     </Tab.Navigator>

--- a/src/screens/SubscribeScreen/SubscribeScreen.style.tsx
+++ b/src/screens/SubscribeScreen/SubscribeScreen.style.tsx
@@ -3,7 +3,10 @@ import styled from '@emotion/native';
 const SubscribeContainer = styled.View`
   margin: 16px;
 `;
-const SubscribeMarketCartWrapper = styled.ScrollView``;
+const SubscribeMarketCartWrapper = styled.ScrollView`
+  width: 100%;
+  height: 100%;
+`;
 
 const S = {SubscribeContainer, SubscribeMarketCartWrapper};
 

--- a/src/screens/SubscribeScreen/SubscribeScreen.style.tsx
+++ b/src/screens/SubscribeScreen/SubscribeScreen.style.tsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/native';
+
+const SubscribeContainer = styled.View`
+  margin: 16px;
+`;
+const SubscribeMarketCartWrapper = styled.ScrollView``;
+
+const S = {SubscribeContainer, SubscribeMarketCartWrapper};
+
+export default S;

--- a/src/screens/SubscribeScreen/index.tsx
+++ b/src/screens/SubscribeScreen/index.tsx
@@ -1,8 +1,63 @@
-import React from 'react';
-import {Text} from 'react-native';
+import React, {useEffect, useState, useCallback} from 'react';
+import {View, Alert, Text, RefreshControl, StyleSheet} from 'react-native';
+import {SubscribeType} from '@/types/Subscribe';
+import {getSubscribeList} from '@/apis/Subscribe';
+import SubscribeMarketCard from '@/components/subscribePage/SubscribeMarketCard';
+import usePullDownRefresh from '@/hooks/usePullDownRefresh';
+import S from './SubscribeScreen.style';
 
 const SubscribeScreen = () => {
-  return <Text>initial</Text>;
+  const [markets, setMarkets] = useState<SubscribeType[] | null>(null);
+
+  const fetchData = useCallback(async () => {
+    const res = await getSubscribeList();
+    if (!res) {
+      Alert.alert('찜 리스트 받아오기 실패');
+      return;
+    }
+    setMarkets(res);
+  }, []);
+  console.log(markets?.length);
+  const {refreshing, onRefresh} = usePullDownRefresh(fetchData);
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  if (!markets) {
+    return (
+      <View>
+        <Text>찜 리스트를 불러오는데 실패했습니다.</Text>
+      </View>
+    );
+  }
+  return (
+    <S.SubscribeContainer>
+      <Text>현재 {markets.length}개 가게를 찜하고 계세요!</Text>
+      <S.SubscribeMarketCartWrapper
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }>
+        {markets.map(item => (
+          <SubscribeMarketCard
+            key={item.id}
+            name={item.name}
+            address={item.address}
+            specificAddress={item.specificAddress}
+            openAt={item.openAt}
+            closeAt={item.closeAt}
+            // TODO: 가게 대표 이미지로 변경, 현재 response 부재
+            thumbnailImage={item.products[0].image}
+          />
+        ))}
+      </S.SubscribeMarketCartWrapper>
+    </S.SubscribeContainer>
+  );
 };
+
+const styles = StyleSheet.create({
+  listContent: {
+    padding: 16,
+  },
+});
 
 export default SubscribeScreen;

--- a/src/screens/SubscribeScreen/index.tsx
+++ b/src/screens/SubscribeScreen/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import {Text} from 'react-native';
+
+const SubscribeScreen = () => {
+  return <Text>initial</Text>;
+};
+
+export default SubscribeScreen;

--- a/src/screens/SubscribeScreen/index.tsx
+++ b/src/screens/SubscribeScreen/index.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState, useCallback} from 'react';
-import {View, Alert, Text, RefreshControl, StyleSheet} from 'react-native';
+import {View, Alert, Text, RefreshControl} from 'react-native';
 import {SubscribeType} from '@/types/Subscribe';
 import {getSubscribeList} from '@/apis/Subscribe';
 import SubscribeMarketCard from '@/components/subscribePage/SubscribeMarketCard';
@@ -54,7 +54,7 @@ const SubscribeScreen = ({navigation}: Props) => {
         {markets.map(item => (
           <SubscribeMarketCard
             key={item.id}
-            marketid={item.id}
+            marketId={item.id}
             name={item.name}
             address={item.address}
             specificAddress={item.specificAddress}
@@ -69,11 +69,5 @@ const SubscribeScreen = ({navigation}: Props) => {
     </S.SubscribeContainer>
   );
 };
-
-const styles = StyleSheet.create({
-  listContent: {
-    padding: 16,
-  },
-});
 
 export default SubscribeScreen;

--- a/src/screens/SubscribeScreen/index.tsx
+++ b/src/screens/SubscribeScreen/index.tsx
@@ -5,8 +5,14 @@ import {getSubscribeList} from '@/apis/Subscribe';
 import SubscribeMarketCard from '@/components/subscribePage/SubscribeMarketCard';
 import usePullDownRefresh from '@/hooks/usePullDownRefresh';
 import S from './SubscribeScreen.style';
+import {StackNavigationProp} from '@react-navigation/stack';
+import {RootStackParamList} from '@/types/StackNavigationType';
 
-const SubscribeScreen = () => {
+type Props = {
+  navigation: StackNavigationProp<RootStackParamList, 'Subscribe'>;
+};
+
+const SubscribeScreen = ({navigation}: Props) => {
   const [markets, setMarkets] = useState<SubscribeType[] | null>(null);
 
   const fetchData = useCallback(async () => {
@@ -17,8 +23,16 @@ const SubscribeScreen = () => {
     }
     setMarkets(res);
   }, []);
-  console.log(markets?.length);
+
   const {refreshing, onRefresh} = usePullDownRefresh(fetchData);
+
+  const onPressStore = (marketId: number) => {
+    navigation.navigate('Detail', {
+      screen: 'Market',
+      params: {marketId},
+    });
+  };
+
   useEffect(() => {
     fetchData();
   }, [fetchData]);
@@ -40,6 +54,7 @@ const SubscribeScreen = () => {
         {markets.map(item => (
           <SubscribeMarketCard
             key={item.id}
+            marketid={item.id}
             name={item.name}
             address={item.address}
             specificAddress={item.specificAddress}
@@ -47,6 +62,7 @@ const SubscribeScreen = () => {
             closeAt={item.closeAt}
             // TODO: 가게 대표 이미지로 변경, 현재 response 부재
             thumbnailImage={item.products[0].image}
+            onPress={onPressStore}
           />
         ))}
       </S.SubscribeMarketCartWrapper>

--- a/src/screens/SubscribeScreen/index.tsx
+++ b/src/screens/SubscribeScreen/index.tsx
@@ -21,7 +21,7 @@ const SubscribeScreen = ({navigation}: Props) => {
       Alert.alert('찜 리스트 받아오기 실패');
       return;
     }
-    setMarkets(res);
+    setMarkets(res.markets);
   }, []);
 
   const {refreshing, onRefresh} = usePullDownRefresh(fetchData);

--- a/src/types/StackNavigationType.ts
+++ b/src/types/StackNavigationType.ts
@@ -9,6 +9,7 @@ export interface HomeStackParamList extends ParamListBase {
   Feed: undefined;
   MyPage: undefined;
   OrderHistory: undefined;
+  Subscribe: undefined;
 }
 
 export interface RegisterStackParamList extends ParamListBase {

--- a/src/types/Subscribe.ts
+++ b/src/types/Subscribe.ts
@@ -1,0 +1,11 @@
+import {ProductType} from './ProductType';
+
+export type SubscribeType = {
+  id: number;
+  name: string;
+  address: string;
+  specificAddress: string;
+  openAt: string;
+  closeAt: string;
+  products: ProductType[];
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resloves: #37 


## 📝작업 내용

- 찜 가게 카드 컴포넌트 제작
- 찜 페이지 제작
- 바텀 탭바 페이지 순서 변경

#### Subscribe.ts
```
type SubscribeType = {
  id: number;
  name: string;
  address: string;
  specificAddress: string;
  openAt: string;
  closeAt: string;
  products: ProductType[];
};
```

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

<img src="https://github.com/user-attachments/assets/09314221-7c93-46e4-a56e-54d7ed607cdd" width="50%" />

안드로이드 이미지가 자꾸 깨지네요.. 빌드 확인했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

가게 카드에서 찜한 가게 삭제 버튼 있으면 좋을듯 합니다.
api 이슈좀 해결되고 디자인 나오면 적용하겠습니다.