### PR TITLE
fix: 주문 내역 표시 및 바텀 아이콘 적용

### DIFF
--- a/src/components/common/TabBar.style.tsx
+++ b/src/components/common/TabBar.style.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/native';
+
+const TabBarContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+`;
+
+const TabBarItemButton = styled.TouchableOpacity`
+  flex: 1;
+`;
+
+const TabBarItem = styled.View`
+  margin: 4px auto;
+  padding: 4px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const TabBarText = styled.Text<{isFocused: boolean}>`
+  ${({theme}) => theme.fonts.body2};
+  color: ${({isFocused, theme}) =>
+    isFocused ? theme.colors.primary : theme.colors.tertiary};
+`;
+
+const S = {
+  TabBarContainer,
+  TabBarItemButton,
+  TabBarItem,
+  TabBarText,
+};
+
+export default S;

--- a/src/components/common/TabBar.tsx
+++ b/src/components/common/TabBar.tsx
@@ -1,38 +1,59 @@
 import React from 'react';
+
 import {BottomTabBarProps} from '@react-navigation/bottom-tabs';
-import {View, TouchableOpacity, Text, Image} from 'react-native';
+
+import {default as AntIcon} from 'react-native-vector-icons/AntDesign';
+import {default as FeatherIcon} from 'react-native-vector-icons/Feather';
+
 import {HomeStackParamList} from '@/types/StackNavigationType';
+
+import S from './TabBar.style';
 
 type TabBarComponentType = {
   [route in keyof HomeStackParamList]: {
     label: string;
-    icon: string;
+    icon: {
+      family: 'AntDesign' | 'Feather';
+      name: string;
+    };
   };
 };
 
 const tabBarData: TabBarComponentType = {
   Feed: {
     label: '홈',
-    icon: 'https://legacy.reactjs.org/logo-og.png',
+    icon: {
+      family: 'Feather',
+      name: 'home',
+    },
   },
   MyPage: {
     label: '마이 페이지',
-    icon: 'https://legacy.reactjs.org/logo-og.png',
+    icon: {
+      family: 'Feather',
+      name: 'user',
+    },
   },
   OrderHistory: {
     label: '주문 내역',
-    icon: 'https://legacy.reactjs.org/logo-og.png',
+    icon: {
+      family: 'AntDesign',
+      name: 'profile',
+    },
   },
   Subscribe: {
     label: '찜',
-    icon: 'https://legacy.reactjs.org/logo-og.png',
+    icon: {
+      family: 'Feather',
+      name: 'heart',
+    },
   },
 };
 
 // TODO: resolve inline style
 const TabBar = ({state, descriptors, navigation}: BottomTabBarProps) => {
   return (
-    <View style={{flexDirection: 'row'}}>
+    <S.TabBarContainer>
       {state.routes.map((route, index) => {
         const {options} = descriptors[route.key];
 
@@ -60,32 +81,35 @@ const TabBar = ({state, descriptors, navigation}: BottomTabBarProps) => {
         };
 
         return (
-          <TouchableOpacity
+          <S.TabBarItemButton
             key={route.key}
             accessibilityRole="button"
             accessibilityState={isFocused ? {selected: true} : {}}
             accessibilityLabel={options.tabBarAccessibilityLabel}
             testID={options.tabBarTestID}
             onPress={onPress}
-            onLongPress={onLongPress}
-            style={{flex: 1}}>
-            <View style={{marginHorizontal: 'auto'}}>
-              <Image
-                source={{uri: icon}}
-                style={{width: 24, height: 24, marginHorizontal: 'auto'}}
-              />
-              <Text
-                style={{
-                  color: isFocused ? '#673ab7' : '#222',
-                  textAlign: 'center',
-                }}>
-                {label}
-              </Text>
-            </View>
-          </TouchableOpacity>
+            onLongPress={onLongPress}>
+            <S.TabBarItem>
+              {icon.family === 'AntDesign' && (
+                <AntIcon
+                  name={icon.name}
+                  size={24}
+                  color={isFocused ? 'rgba(112, 200, 2, 1)' : '#222'}
+                />
+              )}
+              {icon.family === 'Feather' && (
+                <FeatherIcon
+                  name={icon.name}
+                  size={24}
+                  color={isFocused ? 'rgba(112, 200, 2, 1)' : '#222'}
+                />
+              )}
+              <S.TabBarText isFocused={isFocused}>{label}</S.TabBarText>
+            </S.TabBarItem>
+          </S.TabBarItemButton>
         );
       })}
-    </View>
+    </S.TabBarContainer>
   );
 };
 

--- a/src/components/orderHistory/OrderHistory.tsx
+++ b/src/components/orderHistory/OrderHistory.tsx
@@ -1,7 +1,7 @@
 import {OrderType} from '@/types/OrderType';
 import {format} from '@/utils/date';
 import React from 'react';
-import {Image} from 'react-native';
+import {Alert, Image} from 'react-native';
 import HistoryTimeline from './HistoryTimeline';
 
 import S from './OrderHistory.style';
@@ -16,9 +16,8 @@ type Props = {
 const OrderHistory = ({historyList, onPressMarket}: Props) => {
   return (
     <S.OrderContainer>
-      <S.Title>진행중인 주문</S.Title>
       <S.HistoryList>
-        {historyList == null
+        {historyList === null
           ? Array.from({length: 3}).map((_, idx) => (
               <S.HistoryItemSkeleton key={idx} />
             ))
@@ -53,9 +52,10 @@ const OrderHistory = ({historyList, onPressMarket}: Props) => {
               } ${sumOfPrice}원`;
 
               const status =
-                order.ordersStatus === 'ORDERED'
+                order.ordersStatus === 'ORDERED' ||
+                order.ordersStatus === 'ACCEPTED'
                   ? '예약완료'
-                  : order.ordersStatus === 'ACCEPTED'
+                  : order.ordersStatus === 'PICKEDUP'
                     ? '픽업완료'
                     : order.ordersStatus === 'CANCELED'
                       ? '주문취소'
@@ -86,7 +86,7 @@ const OrderHistory = ({historyList, onPressMarket}: Props) => {
                           />
                         </S.TouchableStoreName>
                         {/* TODO: 주문 상세 페이지 추가 @l-lyun */}
-                        {/* <S.OrderDetailButtonContainer>
+                        <S.OrderDetailButtonContainer>
                           <S.OrderDetailButton
                             onPress={() =>
                               Alert.alert(
@@ -97,7 +97,7 @@ const OrderHistory = ({historyList, onPressMarket}: Props) => {
                               주문 상세
                             </S.OrderDetailButtonText>
                           </S.OrderDetailButton>
-                        </S.OrderDetailButtonContainer> */}
+                        </S.OrderDetailButtonContainer>
                       </S.InfoHeader>
                       <S.CreatedAt>{`${format(order.createdAt)}${
                         status != null ? ` · ${status}` : ''
@@ -108,14 +108,28 @@ const OrderHistory = ({historyList, onPressMarket}: Props) => {
                     </S.ItemInfo>
                   </S.HistoryItemSummary>
                   <S.HistoryTimelineContainer>
-                    {order.ordersStatus === 'ACCEPTED' && (
+                    <HistoryTimeline
+                      title="픽업 대기"
+                      timestamp={order.pickupReservedAt}
+                      description={`${format(
+                        order.pickupReservedAt,
+                        'YYYY.MM.DD HH시 mm분',
+                      )}까지 가게로 방문해주세요.`}
+                    />
+                    {/* TODO: 픽업 완료 시간 추가 */}
+                    {order.ordersStatus === 'PICKEDUP' && (
                       <HistoryTimeline
-                        title="픽업 대기"
-                        timestamp={order.pickupReservedAt}
-                        description={`${format(
-                          order.pickupReservedAt,
-                          'YYYY.MM.DD HH시 mm분',
-                        )}까지 가게로 방문해주세요.`}
+                        title="픽업 완료"
+                        timestamp={order.pickupReservedAt + 1000 * 60}
+                        description={'픽업이 완료되었습니다.'}
+                      />
+                    )}
+                    {/* TODO: 주문 취소 시간 추가 */}
+                    {order.ordersStatus === 'CANCELED' && (
+                      <HistoryTimeline
+                        title="주문 취소"
+                        timestamp={order.pickupReservedAt + 1000 * 60}
+                        description={'주문이 취소되었습니다.'}
                       />
                     )}
                   </S.HistoryTimelineContainer>

--- a/src/components/orderHistory/OrderHistory.tsx
+++ b/src/components/orderHistory/OrderHistory.tsx
@@ -41,15 +41,11 @@ const OrderHistory = ({historyList, onPressMarket}: Props) => {
 
               const productLength = order.products.length;
 
-              const sumOfPrice = order.products
-                .reduce((acc, curr) => acc + curr.discountPrice, 0)
-                .toLocaleString();
-
               const description = `${representProduct} ${
                 productLength > 1
                   ? `외 ${productLength - 1}개`
                   : `${order.products[0].count}개`
-              } ${sumOfPrice}원`;
+              } ${order.ordersPrice.toLocaleString()}원`;
 
               const status =
                 order.ordersStatus === 'ORDERED' ||


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

- [ ] 주문 상세 페이지 라우팅 구현
- 주문 내역 표시
- 바텀 아이콘 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
