### PR TITLE
fix: 가게 상세 페이지 조회시 항상 count 0 처리, 장바구니 비어있을시 이동 제어

### DIFF
--- a/src/screens/MarketDetailScreen/MarketDetailPage.tsx
+++ b/src/screens/MarketDetailScreen/MarketDetailPage.tsx
@@ -114,41 +114,6 @@ const MarketDetailPage = ({
       {} as Record<string, ProductType[]>,
     );
 
-  const handleCheckout = async (marketId: number, cartItems: CartItem[]) => {
-    try {
-      const bucketProducts = cartItems.map(cartItem => {
-        const productDetails = products.find(
-          (product): product is ProductType =>
-            product.id === cartItem.productId,
-        );
-
-        if (!productDetails) {
-          throw new Error(`타입 방지 위한 error`);
-        }
-
-        return {
-          count: cartItem.count,
-          id: productDetails.id,
-          name: productDetails.name,
-          image: productDetails.image,
-          originPrice: productDetails.originPrice,
-          discountPrice: productDetails.discountPrice,
-        };
-      });
-
-      const bucketPostValidate = await addToBucket(marketId, bucketProducts);
-      if (bucketPostValidate) {
-        navigation.navigate('CartRoot', {
-          screen: 'Cart',
-        });
-      } else {
-        console.log('add to bucket failed');
-      }
-    } catch (error) {
-      console.error('Error in handleCheckout:', error);
-    }
-  };
-
   const scrollToSection = useCallback(
     (tag: string) => {
       if (scrollViewRef.current && sectionOffsets[tag] !== undefined) {
@@ -251,10 +216,49 @@ const MarketDetailPage = ({
   const handleSubscribe = () => {
     setMarketIsLiked(prevState => !prevState);
   };
+
+  const handleCheckout = async (marketId: number, cartItems: CartItem[]) => {
+    try {
+      const bucketProducts = cartItems.map(cartItem => {
+        const productDetails = products.find(
+          (product): product is ProductType =>
+            product.id === cartItem.productId,
+        );
+
+        if (!productDetails) {
+          throw new Error(`타입 방지 위한 error`);
+        }
+
+        return {
+          count: cartItem.count,
+          id: productDetails.id,
+          name: productDetails.name,
+          image: productDetails.image,
+          originPrice: productDetails.originPrice,
+          discountPrice: productDetails.discountPrice,
+        };
+      });
+
+      const bucketPostValidate = await addToBucket(marketId, bucketProducts);
+      if (bucketPostValidate) {
+        navigation.navigate('CartRoot', {
+          screen: 'Cart',
+        });
+      } else {
+        console.log('add to bucket failed');
+      }
+    } catch (error) {
+      console.error('Error in handleCheckout:', error);
+    }
+  };
   const addProductToBucket = async (
     marketId: number,
     addProducts: CartItem[],
   ) => {
+    if (addProducts.length === 0) {
+      Alert.alert('장바구니가 비어있습니다.');
+      return;
+    }
     if (!(await validateBucket(marketId))) {
       Alert.alert(
         '기존에 담아두었던 장바구니가 존재합니다.',
@@ -278,6 +282,7 @@ const MarketDetailPage = ({
       return;
     }
     handleCheckout(marketId, addProducts);
+    setCart([]);
   };
 
   const caculateRemainingPickupTime = () => {

--- a/src/screens/MarketDetailScreen/MarketDetailPage.tsx
+++ b/src/screens/MarketDetailScreen/MarketDetailPage.tsx
@@ -268,6 +268,7 @@ const MarketDetailPage = ({
             text: '예',
             onPress: () => {
               handleCheckout(marketId, addProducts);
+              setCart([]);
             },
           },
           {


### PR DESCRIPTION


## 📝작업 내용
- 페이지 리로드될때마다 프론트 cart상태만 0으로 처리(직전 handleCheckout에서 이미 서버에 담은 cart를 넘겨서 상관없음)
- 장바구니 비어있을시 네비게이트 막고 Alert 띄웁니다

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- count 항상 0으로 처리하는게 맞나 싶은데 내일 얘기해보죠 일단 얘기한대로 반영했습니다

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
