### PR TITLE
fix: getProfile api 로직으로 변경

### DIFF
--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -194,47 +194,12 @@ export const logout = async (): Promise<boolean> => {
   }
 };
 
-export const getProfile = async () => {
+export const getProfile = async (): Promise<UserType | null> => {
   try {
-    const storageRes: SessionType | null = await getStorage('session');
-    if (!storageRes) {
-      return null;
-    }
-
-    let res: UserType | null = null;
-
-    if (storageRes.OAuthProvider === 'KAKAO') {
-      const kakaoProfileRes = await getKakaoProfile();
-
-      if (kakaoProfileRes) {
-        res = {
-          id: kakaoProfileRes.id,
-          name: kakaoProfileRes.nickname,
-          image: kakaoProfileRes.profileImageUrl,
-          provider: 'KAKAO',
-        };
-      }
-    } else if (storageRes.OAuthProvider === 'NAVER') {
-      const naverProfileRes = await NaverLogin.getProfile(
-        storageRes.accessToken,
-      );
-
-      if (
-        naverProfileRes.message === 'success' &&
-        naverProfileRes.resultcode === '00'
-      ) {
-        res = {
-          id: naverProfileRes.response.id,
-          name: naverProfileRes.response.name,
-          image: naverProfileRes.response.profile_image ?? '',
-          provider: 'NAVER',
-        };
-      }
-    }
-
+    const res = await apiClient.get<UserType | null>(`/members/profiles`);
     return res;
   } catch (error) {
-    console.error('프로필 불러오기 에러:', error);
+    console.error(`Error fetching profile: ${error}`);
     return null;
   }
 };

--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -1,5 +1,4 @@
 import {
-  getProfile as getKakaoProfile,
   login as kakaoLogin,
   logout as kakaoLogout,
 } from '@react-native-seoul/kakao-login';

--- a/src/types/UserType.ts
+++ b/src/types/UserType.ts
@@ -4,7 +4,7 @@ import {SessionType} from './Session';
 export type UserType = {
   id: number | string;
   name: string;
-  image: string;
+  image?: string;
   provider: SessionType['OAuthProvider'];
   phoneNumber?: string;
   email?: string;


### PR DESCRIPTION
## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- getProfile api 적용했습니다.

### 스크린샷 (선택)
<img width="397" alt="image" src="https://github.com/user-attachments/assets/2ac996a1-4676-4ffd-956a-1644aa773b28">

## 💬리뷰 요구사항(선택)
- 프로필 이미지 백엔드에서 저장 안하고있다고 해서 일단 옵셔널로 고치고 TODO에 기입했습니다.

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
