### PR TITLE
fix: orderId 6자리 해쉬값으로 변경

### DIFF
--- a/src/components/orderDetail/OrderDescription.tsx
+++ b/src/components/orderDetail/OrderDescription.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {format} from '@/utils/date';
 import S from './OrderDescription.style';
+import {to6DigitHash} from '@/utils/hash';
 
 type Props = {
   id: string;
@@ -54,6 +55,7 @@ const OrderCustomerInfo = ({
   marketAddress,
 }: Props) => {
   const orderStatusText = getOrderStatusText(orderStatus);
+  const hashOrderId = to6DigitHash(id);
   return (
     <S.Container>
       <S.OrderStatusText>{orderStatusText}</S.OrderStatusText>
@@ -66,7 +68,9 @@ const OrderCustomerInfo = ({
         <S.OrderDescriptionText>
           주문자: {orderMemberName}
         </S.OrderDescriptionText>
-        <S.OrderDescriptionText>주문 번호: {id}</S.OrderDescriptionText>
+        <S.OrderDescriptionText>
+          주문 번호: {hashOrderId}
+        </S.OrderDescriptionText>
         <S.OrderDescriptionText>
           {`주문 일시: ${format(new Date(createdAt).getTime(), 'YYYY. MM. DD. (ddd) A hh:mm')}`}
         </S.OrderDescriptionText>

--- a/src/screens/OrderDoneScreen/index.tsx
+++ b/src/screens/OrderDoneScreen/index.tsx
@@ -4,19 +4,20 @@ import React from 'react';
 import {Text, View} from 'react-native';
 import {Button, Title} from 'react-native-paper';
 import S from './OrderDoneScreen.style';
+import {to6DigitHash} from '@/utils/hash';
 
 type Props = StackScreenProps<DetailStackParamList, 'OrderDone'>;
 
 const OrderDoneScreen = ({navigation, route}: Props) => {
   const {orderId, products, originPrice, discountPrice} = route.params;
-
+  const hashOrderId = to6DigitHash(orderId);
   return (
     <S.OrderDoneContainer>
       <S.OrderDoneCard>
         <Title>주문완료</Title>
         <View>
           <Text>주문이 완료되었습니다.</Text>
-          <Text>{`주문번호: ${orderId}`}</Text>
+          <Text>{`주문번호: ${hashOrderId}`}</Text>
         </View>
       </S.OrderDoneCard>
       <S.OrderDoneCard>

--- a/src/types/StackNavigationType.ts
+++ b/src/types/StackNavigationType.ts
@@ -22,7 +22,7 @@ export interface DetailStackParamList extends ParamListBase {
   Market: {marketId: number};
   Payment: undefined;
   OrderDone: {
-    orderId: number;
+    orderId: string;
     products: OrderType['products'];
     originPrice: number;
     discountPrice: number;

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-bitwise */
 const crcTable = new Uint32Array(256);
 for (let i = 0; i < 256; i++) {
   let crc = i;
@@ -21,7 +22,3 @@ export const to6DigitHash = (str: string): string => {
   const crc = crc32(str).toString(16);
   return crc.slice(0, 6).toUpperCase();
 };
-
-// 테스트
-const hash = to6DigitHash('Your long string here');
-console.log(hash); // 출력 예시: "1be4a9"

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,27 @@
+const crcTable = new Uint32Array(256);
+for (let i = 0; i < 256; i++) {
+  let crc = i;
+  for (let j = 0; j < 8; j++) {
+    crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+  }
+  crcTable[i] = crc;
+}
+
+const crc32 = (str: string): number => {
+  let crc = 0xffffffff;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    crc = (crc >>> 8) ^ crcTable[(crc ^ char) & 0xff];
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+// 6자리 해시 생성 함수
+export const to6DigitHash = (str: string): string => {
+  const crc = crc32(str).toString(16);
+  return crc.slice(0, 6).toUpperCase();
+};
+
+// 테스트
+const hash = to6DigitHash('Your long string here');
+console.log(hash); // 출력 예시: "1be4a9"


### PR DESCRIPTION
## 📝작업 내용
- hash function 사용해서 뷰 단에서만 주문번호 유지하도록 했습니다.
- 어드민에서도 동일 함수 적용시 클라 == 어드민 확인했습니다.

### 스크린샷 (선택)
| ![Image 1](https://github.com/user-attachments/assets/adff2eaa-90ae-4558-91c1-9849f3a9e873) | ![Image 2](https://github.com/user-attachments/assets/69e83db2-8289-4fed-8912-6443094c0b36) |
|:--:|:--:|

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
동일 함수 적용해서 어드민에서 피알 올리겠습니다.