### PR TITLE
fix: 예약하기 플로우에 맞춘 워딩 변경

### DIFF
--- a/src/components/orderPage/PaymentSummary.style.tsx
+++ b/src/components/orderPage/PaymentSummary.style.tsx
@@ -8,9 +8,13 @@ const Header = styled.View`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+`;
 
+const HeaderPaymentMethod = styled.View`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
   margin-bottom: 16px;
-
   border-bottom-width: 1px;
   border-bottom-color: #b5b5b5;
 `;
@@ -42,6 +46,7 @@ const S = {
   PaymentSummaryItemList,
   Header,
   ItemText,
+  HeaderPaymentMethod,
 };
 
 export default S;

--- a/src/components/orderPage/PaymentSummary.tsx
+++ b/src/components/orderPage/PaymentSummary.tsx
@@ -23,6 +23,7 @@ type Props = {
   discountPrice: number;
 };
 
+// TODO: HeaderPaymentMethod 삭제 후 border-bottom 이동
 const PaymentSummary = ({originPrice, discountPrice}: Props) => {
   return (
     <S.Card>
@@ -30,6 +31,10 @@ const PaymentSummary = ({originPrice, discountPrice}: Props) => {
         <S.HeaderText>결제금액</S.HeaderText>
         <S.HeaderText>{`${discountPrice.toLocaleString()}원`}</S.HeaderText>
       </S.Header>
+      <S.HeaderPaymentMethod>
+        <S.HeaderText>결제방법 </S.HeaderText>
+        <S.HeaderText>만나서 결제</S.HeaderText>
+      </S.HeaderPaymentMethod>
       <S.PaymentSummaryItemList>
         <PaymentSummaryItem
           title="주문금액"
@@ -38,6 +43,11 @@ const PaymentSummary = ({originPrice, discountPrice}: Props) => {
         <PaymentSummaryItem
           title="할인금액"
           price={`-${(originPrice - discountPrice).toLocaleString()}원`}
+          primary
+        />
+        <PaymentSummaryItem
+          title="인앱 결제는 차후 추가될 예정입니다!"
+          price=" "
           primary
         />
       </S.PaymentSummaryItemList>

--- a/src/screens/ShoppingCartScreen/ShoppingCartPage.tsx
+++ b/src/screens/ShoppingCartScreen/ShoppingCartPage.tsx
@@ -62,7 +62,7 @@ const ShoppingCartPage = ({
           discountPrice={discountPrice}
         />
         <BottomButton onPress={onPressPayment}>
-          {`${discountPrice.toLocaleString()}원 결제하기`}
+          {`${discountPrice.toLocaleString()}원 예약하기`}
         </BottomButton>
       </S.ScrollView>
     </S.CartPage>


### PR DESCRIPTION
## 📝작업 내용
- PaymentSummary 내 결제 수단 표시 추가(차후 인앱결제 기능 부착시 삭제해도 될 것 같아요)
- 결제하기 -> 예약하기로 모두 변경
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)
<p align="center">
  <img src="https://github.com/user-attachments/assets/57fb38ae-9650-4aa0-a5e1-7cec56eb771e" alt="Image 1" width="45%">
  <img src="https://github.com/user-attachments/assets/8c4666d2-df7e-425f-973f-6d9890bed90d" alt="Image 2" width="45%">
</p>

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
