### PR TITLE
fix: fcm 로직 및 스플래시 스크린 초기 해결

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,35 +3,30 @@ import './gesture-handler';
 import RootProvider from './src/context';
 import AppNavigator from './src/navigation';
 import SplashScreen from 'react-native-splash-screen';
+import {setUpPushNotificationHandlers} from './src/utils/notification';
 import {requestNotificationPermission} from './src/utils/notification';
-import messaging from '@react-native-firebase/messaging';
+
+// const isDarkMode = useColorScheme() === 'dark';
 
 function App(): React.JSX.Element {
-  // const isDarkMode = useColorScheme() === 'dark';
   useEffect(() => {
     const initializeApp = async () => {
       try {
-        //TODO: fcm 토큰 등록 위치 논의 후 따로 분리 예정
+        // 푸시 알림 핸들러 설정
         await requestNotificationPermission();
-        setupForegroundMessageHandler();
+        await setUpPushNotificationHandlers();
+
+        // 알림 권한 요청 (필요 시)
+
+        // 스플래시 화면 숨기기
+        console.log('앱 초기화 완료');
       } catch (error) {
-        console.error('splash screen error:', error);
-      } finally {
-        SplashScreen.hide();
+        console.error('앱 초기화 중 오류 발생:', error);
       }
     };
-    const setupForegroundMessageHandler = () => {
-      const unsubscribe = messaging().onMessage(async remoteMessage => {
-        console.log('[+] Foreground Message:', JSON.stringify(remoteMessage));
-      });
 
-      return unsubscribe;
-    };
     initializeApp();
-    return () => {
-      const unsubscribe = setupForegroundMessageHandler();
-      unsubscribe();
-    };
+    SplashScreen.hide();
   }, []);
 
   return (

--- a/src/apis/Login.ts
+++ b/src/apis/Login.ts
@@ -16,7 +16,6 @@ import appleAuth from '@invertase/react-native-apple-authentication';
 
 // 네이버 로그인 관련 설정
 const {RNNaverLogin} = NativeModules;
-
 const initializeNaver = ({
   appName,
   consumerKey,

--- a/src/screens/FeedScreen/index.tsx
+++ b/src/screens/FeedScreen/index.tsx
@@ -152,8 +152,6 @@ const FeedScreen = ({navigation}: Props) => {
   const {refreshing, onRefresh} = usePullDownRefresh(initializeData);
 
   useEffect(() => {
-    initializeData();
-
     const handleAppStateChange = (nextAppState: AppStateStatus) => {
       console.log('AppState 변경:', nextAppState);
       if (nextAppState === 'active') {

--- a/src/screens/FeedScreen/index.tsx
+++ b/src/screens/FeedScreen/index.tsx
@@ -2,17 +2,23 @@ import {StackNavigationProp} from '@react-navigation/stack';
 import React, {useCallback, useEffect, useState} from 'react';
 import {Alert, RefreshControl, Text, View} from 'react-native';
 import Geolocation from 'react-native-geolocation-service';
-import {requestLocationPermission} from '@/utils/notification';
-
+import {
+  changeLocationPermission,
+  isNotificationPermissionEnabled,
+  requestLocationPermission,
+  requestNotificationPermission,
+  setUpPushNotificationHandlers,
+} from '@/utils/notification';
+import {AppState, AppStateStatus} from 'react-native';
 import {getMarketList} from '@/apis';
 import {BottomButton} from '@/components/common';
 import {Market} from '@/components/feedPage';
 import usePullDownRefresh from '@/hooks/usePullDownRefresh';
 import {MarketType} from '@/types/Market';
 import {RootStackParamList} from '@/types/StackNavigationType';
-
 import S from './SearchBar.style';
-
+import messaging from '@react-native-firebase/messaging';
+import {registerFCMToken} from '@/apis';
 type Props = {
   navigation: StackNavigationProp<RootStackParamList, 'Home'>;
 };
@@ -24,7 +30,6 @@ const FeedScreen = ({navigation}: Props) => {
     userLatitude: number;
     userLongitude: number;
   } | null>(null);
-
   const fetchData = useCallback(async () => {
     const res = await getMarketList(
       0,
@@ -79,6 +84,18 @@ const FeedScreen = ({navigation}: Props) => {
 
   const initializeData = useCallback(async () => {
     const gotLocation = await getCurrentLocation();
+    await requestNotificationPermission();
+    const isNotificationOn = await isNotificationPermissionEnabled();
+    if (isNotificationOn) {
+      console.log('isNotificationOn:', isNotificationOn);
+      setUpPushNotificationHandlers();
+      const token = await messaging().getToken();
+      await registerFCMToken(token);
+      await setUpPushNotificationHandlers();
+      console.log('FCM Token:', token);
+    } else {
+      await changeLocationPermission();
+    }
     if (gotLocation) {
       console.log('위치를 받아와서 fetch 실행......');
       await fetchData();
@@ -134,11 +151,27 @@ const FeedScreen = ({navigation}: Props) => {
 
   const {refreshing, onRefresh} = usePullDownRefresh(initializeData);
 
-  useEffect(() => {}, [navigation]);
-
   useEffect(() => {
     initializeData();
-  }, [initializeData]);
+
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      console.log('AppState 변경:', nextAppState);
+      if (nextAppState === 'active') {
+        initializeData();
+      } else if (nextAppState === 'background') {
+        console.log('앱이 백그라운드로 이동');
+      }
+    };
+
+    const subscription = AppState.addEventListener(
+      'change',
+      handleAppStateChange,
+    );
+    return () => {
+      console.log('AppState 이벤트 클린업');
+      subscription.remove();
+    };
+  }, [initializeData, navigation]);
 
   if (marketList === null) {
     return (

--- a/src/screens/SettingScreen/index.tsx
+++ b/src/screens/SettingScreen/index.tsx
@@ -7,7 +7,9 @@ import {
   isNotificationPermissionEnabled,
   requestLocationPermission,
 } from '@/utils/notification';
-
+import messaging from '@react-native-firebase/messaging';
+import {registerFCMToken} from '@/apis';
+import {setUpPushNotificationHandlers} from '@/utils/notification';
 const SettingScreen = () => {
   const [isNotificationOn, setIsNotificationOn] = useState(false);
   const [isLocationOn, setIsLocationOn] = useState<
@@ -18,6 +20,12 @@ const SettingScreen = () => {
     try {
       const isEnabled = await isNotificationPermissionEnabled();
       setIsNotificationOn(isEnabled);
+      if (isEnabled) {
+        const token = await messaging().getToken();
+        await registerFCMToken(token);
+        await setUpPushNotificationHandlers();
+        console.log('FCM Token:', token);
+      }
     } catch (error) {
       console.error('체크 실패', error);
     }

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -1,7 +1,6 @@
 import messaging from '@react-native-firebase/messaging';
 import notifee, {AndroidImportance} from '@notifee/react-native';
 import {PermissionsAndroid, Platform, Alert, Linking} from 'react-native';
-import {registerFCMToken} from '@/apis/Fcm';
 import {PERMISSIONS, request, RESULTS} from 'react-native-permissions';
 export const requestNotificationPermission = async () => {
   if (Platform.OS === 'ios') {
@@ -23,10 +22,6 @@ export const requestNotificationPermission = async () => {
       return;
     }
   }
-  const token = await messaging().getToken();
-  await registerFCMToken(token);
-  setUpPushNotificationHandlers();
-  console.log('FCM Token:', token);
 };
 
 const isIOSNotificationPermissionEnabled = async (): Promise<boolean> => {
@@ -56,29 +51,11 @@ export const isNotificationPermissionEnabled = async (): Promise<boolean> => {
 const requestAndroidPermission = async (): Promise<boolean> => {
   const granted = await PermissionsAndroid.request(
     PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
-    {
-      title: '푸시 알림 권한 요청',
-      message: '알림을 활성화하려면 권한이 필요합니다.',
-      buttonNeutral: '나중에',
-      buttonNegative: '취소',
-      buttonPositive: '확인',
-    },
   );
-
   return granted === PermissionsAndroid.RESULTS.GRANTED;
 };
 
 export const changeNotificationPermission = async () => {
-  const authStatus = await isNotificationPermissionEnabled();
-  console.log('test');
-  if (authStatus) {
-    console.log('fcm 권한', authStatus);
-  } else {
-    console.log('fcm 권한', authStatus);
-    const token = await messaging().getToken();
-    await registerFCMToken(token);
-    setUpPushNotificationHandlers();
-  }
   Alert.alert(
     '알림 권한 활성화',
     '알림 권한을 변경하려면 설정에서 변경해야 합니다.',
@@ -95,7 +72,7 @@ export const changeNotificationPermission = async () => {
   );
 };
 
-const setUpPushNotificationHandlers = () => {
+export const setUpPushNotificationHandlers = async () => {
   messaging().onMessage(async remoteMessage => {
     console.log('Foreground Message:', remoteMessage);
     await displayNotification(remoteMessage);


### PR DESCRIPTION
## 📝작업 내용
초기 화면 진입 잘 합니다.

아까 논의 나눴던 로직 거의 다 고친 것 같은데,
제일 초기 상황(기기 새로 만든 상황)에서 소셜로그인 시 네이버/카카오 정보가 저장안되어있어서 앱이 메트로랑 끊겨
테스트가 힘든 듯 합니다.. 빌드 터져서 실기기 못해보고 올립니다.
내일 상민이형이랑 오전에 서버로그 보면서 수정하겠습니다.

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
