### PR TITLE
fix: 비회원 유저 로그인으로 유도

### DIFF
--- a/src/screens/MarketDetailScreen/MarketDetailPage.tsx
+++ b/src/screens/MarketDetailScreen/MarketDetailPage.tsx
@@ -23,6 +23,7 @@ import {RootStackParamList} from '@/types/StackNavigationType';
 import {zeroPad} from '@utils/date';
 
 import S from './MarketDetail.style';
+import useProfile from '@/hooks/useProfile';
 
 type CartItem = {
   productId: number;
@@ -58,6 +59,8 @@ const MarketDetailPage = ({
 
   const {mutateAsync: validateBucket} = useValidateBucket();
   const {mutateAsync: addToBucket} = useAddToBucket();
+
+  const {profile} = useProfile();
 
   const handleCountChange = (productId: number, newCount: number) => {
     handleCart(
@@ -408,8 +411,15 @@ const MarketDetailPage = ({
         ))}
       </S.MenuScrollView>
 
-      <BottomButton onPress={() => addProductToBucket(id, cart)}>
-        예약하기 ({cart.length})
+      <BottomButton
+        onPress={() => {
+          if (profile) {
+            addProductToBucket(id, cart);
+          } else {
+            navigation.navigate('Register', {screen: 'Login'});
+          }
+        }}>
+        {profile ? `예약하기 (${cart.length})` : `로그인하고 장바구니에 담기`}
       </BottomButton>
     </S.MarketDetailInfoView>
   );

--- a/src/screens/ShoppingCartScreen/index.tsx
+++ b/src/screens/ShoppingCartScreen/index.tsx
@@ -15,22 +15,11 @@ type Props = {
   navigation: StackNavigationProp<RootStackParamList, 'Home'>;
 };
 
-const ShoppingCartScreen = ({navigation}: Props) => {
+const ValideShoppingCart = ({navigation}: Props) => {
   const {data: cart, isLoading} = useBucketList();
-  const {profile} = useProfile();
 
   if (isLoading) {
     return <ActivityIndicator animating size="large" />;
-  }
-
-  if (!profile) {
-    return (
-      <EmptyComponent
-        title="로그인 후 판매 중인 반찬을 예약해보세요."
-        onPress={() => navigation.navigate('Register', {screen: 'Login'})}
-        buttonText="로그인하러 가기"
-      />
-    );
   }
 
   if (!cart || !cart.products) {
@@ -44,6 +33,21 @@ const ShoppingCartScreen = ({navigation}: Props) => {
   }
 
   return <ShoppingCartPage navigation={navigation} cartData={cart} />;
+};
+
+const ShoppingCartScreen = ({navigation}: Props) => {
+  const {profile} = useProfile();
+
+  if (!profile) {
+    return (
+      <EmptyComponent
+        title="로그인 후 판매 중인 반찬을 예약해보세요."
+        onPress={() => navigation.navigate('Register', {screen: 'Login'})}
+        buttonText="로그인하러 가기"
+      />
+    );
+  }
+  return <ValideShoppingCart navigation={navigation} />;
 };
 
 export default ShoppingCartScreen;


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

close: #163 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 비회원이 장바구니에 담지 못하도록 로그인으로 유도
- 장바구니 화면에서 비회원의 경우 장바구니 조회 api를 호출하지 않도록 방지

### 스크린샷 (선택)

![Screenshot_1741274222](https://github.com/user-attachments/assets/12049da0-ccb9-4aa1-9f28-d39a75337f15)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
