### PR TITLE
feat: 고객 리뷰 페이지 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@ xmlns:tools="http://schemas.android.com/tools" package="com.ummgoban.momchanpick
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
       android:name=".MainApplication"

--- a/ios/ClientApp/Info.plist
+++ b/ios/ClientApp/Info.plist
@@ -77,6 +77,12 @@
 	<string>이 앱은 항상 위치 정보를 사용합니다.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>이 앱은 위치 정보를 사용합니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>We need access to your camera to take pictures.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>We need access to your photo library to display images.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>AntDesign.ttf</string>

--- a/ios/ClientApp/PrivacyInfo.xcprivacy
+++ b/ios/ClientApp/PrivacyInfo.xcprivacy
@@ -28,6 +28,7 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>C617.1</string>
+				<string>3B52.1</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1351,6 +1351,27 @@ PODS:
     - Yoga
   - react-native-geolocation-service (5.3.1):
     - React
+  - react-native-image-picker (8.2.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-nmap (0.0.67):
     - NMapsMap
     - React
@@ -1813,6 +1834,7 @@ DEPENDENCIES:
   - react-native-encrypted-storage (from `../node_modules/react-native-encrypted-storage`)
   - "react-native-geolocation (from `../node_modules/@react-native-community/geolocation`)"
   - react-native-geolocation-service (from `../node_modules/react-native-geolocation-service`)
+  - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-nmap (from `../node_modules/react-native-naver-map`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
@@ -1963,6 +1985,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/geolocation"
   react-native-geolocation-service:
     :path: "../node_modules/react-native-geolocation-service"
+  react-native-image-picker:
+    :path: "../node_modules/react-native-image-picker"
   react-native-nmap:
     :path: "../node_modules/react-native-naver-map"
   react-native-safe-area-context:
@@ -2108,6 +2132,7 @@ SPEC CHECKSUMS:
   react-native-encrypted-storage: 569d114e329b1c2c2d9f8c84bcdbe4478dda2258
   react-native-geolocation: 4e579df11fd10f90eae937e6040d71523fc6addc
   react-native-geolocation-service: 32b2c2a3b91e70ce2a8d0c684801aaeb0a07e0ec
+  react-native-image-picker: 63689af72a96da88452073026cc657ecdf08004a
   react-native-nmap: 5217c47f228be1da2f91732152c0b0ee5a69dc28
   react-native-safe-area-context: fdb0a66feac038cb6eb1edafcf2ccee2b5cf0284
   react-native-splash-screen: 95994222cc95c236bd3cdc59fe45ed5f27969594

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-native-encrypted-storage": "^4.0.3",
     "react-native-geolocation-service": "^5.3.1",
     "react-native-gesture-handler": "^2.18.1",
+    "react-native-image-picker": "^8.2.0",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-naver-map": "https://github.com/zerocho/react-native-naver-map",
     "react-native-paper": "^5.12.5",

--- a/src/components/common/TextInput/TextInput.tsx
+++ b/src/components/common/TextInput/TextInput.tsx
@@ -16,7 +16,6 @@ type TextInputProps = {
   errorMessage?: string;
   errorStyle?: StyleProp<TextStyle>;
   style?: StyleProp<ViewStyle>;
-  inputStyle?: StyleProp<TextStyle>;
 } & Omit<ReactNativePaperTextInputProps, 'mode' | 'label'>;
 
 /**

--- a/src/components/common/TextInput/TextInput.tsx
+++ b/src/components/common/TextInput/TextInput.tsx
@@ -31,7 +31,6 @@ const TextInput = ({
   errorMessage,
   errorStyle,
   style,
-  inputStyle,
   ...props
 }: TextInputProps) => {
   const value = props.value;
@@ -50,7 +49,7 @@ const TextInput = ({
           <ReactNativePaperTextInput
             {...props}
             mode="outlined"
-            style={[styles.input, inputStyle]}
+            style={styles.input}
             label={undefined}
             outlineStyle={
               value && validation && !validation(value)

--- a/src/components/common/TextInput/TextInput.tsx
+++ b/src/components/common/TextInput/TextInput.tsx
@@ -16,6 +16,7 @@ type TextInputProps = {
   errorMessage?: string;
   errorStyle?: StyleProp<TextStyle>;
   style?: StyleProp<ViewStyle>;
+  inputStyle?: StyleProp<TextStyle>;
 } & Omit<ReactNativePaperTextInputProps, 'mode' | 'label'>;
 
 /**
@@ -30,6 +31,7 @@ const TextInput = ({
   errorMessage,
   errorStyle,
   style,
+  inputStyle,
   ...props
 }: TextInputProps) => {
   const value = props.value;
@@ -48,7 +50,7 @@ const TextInput = ({
           <ReactNativePaperTextInput
             {...props}
             mode="outlined"
-            style={styles.input}
+            style={[styles.input, inputStyle]}
             label={undefined}
             outlineStyle={
               value && validation && !validation(value)

--- a/src/components/orderHistory/OrderHistory.style.tsx
+++ b/src/components/orderHistory/OrderHistory.style.tsx
@@ -4,158 +4,164 @@ import {Platform} from 'react-native';
 // TODO: 각 씬의 margin horizontal을 24px로 설정
 // programmatic하게 margin을 주기
 
-const OrderContainer = styled.View`
-  display: flex;
+const S = {
+  OrderContainer: styled.View`
+    display: flex;
 
-  padding: 20px 0;
-`;
+    padding: 20px 0;
+  `,
 
-const Title = styled.Text`
-  font-size: 20px;
-  line-height: 30px;
-  font-weight: 600;
+  Title: styled.Text`
+    font-size: 20px;
+    line-height: 30px;
+    font-weight: 600;
 
-  margin: 0 24px 12px;
-`;
+    margin: 0 24px 12px;
+  `,
 
-const HistoryList = styled.View`
-  display: flex;
-  gap: 12px;
-`;
+  HistoryList: styled.View`
+    display: flex;
+    gap: 12px;
+  `,
 
-const HistoryItemCSS = css`
-  display: flex;
-  gap: 24px;
+  HistoryItem: styled.View`
+    display: flex;
+    gap: 24px;
 
-  padding: 20px 24px;
-  background-color: #ffffff;
+    padding: 20px 24px;
+    background-color: #ffffff;
 
-  box-shadow: 0px 4px;
-  box-shadow-color: rgba(0, 0, 0, 0.08);
-`;
+    box-shadow: 0px 4px;
+    box-shadow-color: rgba(0, 0, 0, 0.08);
 
-const HistoryItem = styled.View`
-  ${HistoryItemCSS}
-
-  ${Platform.OS === 'ios'
-    ? `shadow-radius: 4px;
+    ${Platform.OS === 'ios'
+      ? `shadow-radius: 4px;
       shadow-offset: 0px 4px;
       shadow-opacity: 0.08;`
-    : Platform.OS === 'android'
-      ? 'elevation: 11;'
-      : ''}
-`;
+      : Platform.OS === 'android'
+        ? 'elevation: 11;'
+        : ''}
+  `,
 
-const HistoryItemSkeleton = styled.View`
-  ${HistoryItemCSS}
+  HistoryItemSkeleton: styled.View`
+    display: flex;
+    gap: 24px;
 
-  min-height: 200px;
-`;
+    padding: 20px 24px;
+    background-color: #ffffff;
 
-const HistoryItemSummary = styled.View`
-  display: flex;
-  flex-direction: row;
-  gap: 12px;
-`;
+    box-shadow: 0px 4px;
+    box-shadow-color: rgba(0, 0, 0, 0.08);
 
-const ItemInfo = styled.View`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+    min-height: 200px;
+  `,
 
-  flex: 1;
-`;
+  HistoryItemSummary: styled.View`
+    display: flex;
+    flex-direction: row;
+    gap: 12px;
+  `,
 
-const StoreImage = styled.Image`
-  width: 64px;
-  height: 64px;
+  ItemInfo: styled.View`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 
-  border-radius: 32px;
-`;
+    flex: 1;
+  `,
 
-const InfoHeader = styled.View`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-`;
+  StoreImage: styled.Image`
+    width: 64px;
+    height: 64px;
 
-const TouchableStoreName = styled.TouchableOpacity`
-  display: flex;
-  flex-direction: row;
+    border-radius: 32px;
+  `,
 
-  align-items: center;
-  gap: 4px;
+  InfoHeader: styled.View`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  `,
 
-  max-width: 60%;
-`;
+  TouchableStoreName: styled.TouchableOpacity`
+    display: flex;
+    flex-direction: row;
 
-const StoreName = styled.Text`
-  font-size: 20px;
-  line-height: 24px;
-  font-weight: 600;
-`;
+    align-items: center;
+    gap: 4px;
 
-const OrderDetailButtonContainer = styled.View`
-  width: auto;
-  height: 26px;
+    max-width: 60%;
+  `,
 
-  box-sizing: border-box;
+  StoreName: styled.Text`
+    font-size: 20px;
+    line-height: 24px;
+    font-weight: 600;
+  `,
 
-  border-radius: 15px;
-  border: 1px solid #ebebeb;
-`;
+  OrderDetailButtonContainer: styled.View`
+    width: auto;
+    height: 26px;
 
-const OrderDetailButton = styled.TouchableOpacity``;
+    box-sizing: border-box;
 
-const OrderDetailButtonText = styled.Text`
-  padding: 2px 10px;
-  color: #222222;
+    border-radius: 15px;
+    border: 1px solid #ebebeb;
+  `,
 
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 22px;
-  letter-spacing: -0.408px;
-`;
+  OrderDetailButton: styled.TouchableOpacity``,
 
-const CreatedAt = styled.Text`
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 20px;
+  OrderDetailButtonText: styled.Text`
+    padding: 2px 10px;
+    color: #222222;
 
-  color: #b5b5b5;
-`;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 22px;
+    letter-spacing: -0.408px;
+  `,
 
-const Description = styled.Text`
-  font-size: 14px;
-  line-height: 20px;
+  ReviewCreateButtonContainer: styled.View`
+    width: auto;
+    height: 26px;
 
-  word-wrap: break-word;
-  word-break: keep-all;
-`;
+    box-sizing: border-box;
 
-const HistoryTimelineContainer = styled.View`
-  display: flex;
-  flex-direction: column;
-`;
+    border-radius: 15px;
+    border: 1px solid #ebebeb;
+  `,
 
-const S = {
-  OrderContainer,
-  Title,
-  HistoryList,
-  HistoryItem,
-  HistoryItemSkeleton,
-  HistoryItemSummary,
-  ItemInfo,
-  StoreImage,
-  InfoHeader,
-  TouchableStoreName,
-  StoreName,
-  OrderDetailButtonContainer,
-  OrderDetailButton,
-  OrderDetailButtonText,
-  CreatedAt,
-  Description,
-  HistoryTimelineContainer,
+  ReviewCreateButton: styled.TouchableOpacity``,
+
+  ReviewCreateButtonText: styled.Text`
+    padding: 2px 10px;
+    color: #222222;
+
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 22px;
+    letter-spacing: -0.408px;
+  `,
+  CreatedAt: styled.Text`
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 20px;
+
+    color: #b5b5b5;
+  `,
+
+  Description: styled.Text`
+    font-size: 14px;
+    line-height: 20px;
+
+    word-wrap: break-word;
+    word-break: keep-all;
+  `,
+
+  HistoryTimelineContainer: styled.View`
+    display: flex;
+    flex-direction: column;
+  `,
 };
 
 export default S;

--- a/src/components/orderHistory/OrderHistory.style.tsx
+++ b/src/components/orderHistory/OrderHistory.style.tsx
@@ -1,4 +1,4 @@
-import styled, {css} from '@emotion/native';
+import styled from '@emotion/native';
 import {Platform} from 'react-native';
 
 // TODO: 각 씬의 margin horizontal을 24px로 설정

--- a/src/components/orderHistory/OrderHistory.tsx
+++ b/src/components/orderHistory/OrderHistory.tsx
@@ -86,7 +86,25 @@ const OrderHistory = ({historyList, onPressMarket}: Props) => {
                             height={24}
                           />
                         </S.TouchableStoreName>
-                        {/* TODO: 주문 상세 페이지 추가 @l-lyun */}
+                        {order.ordersStatus === 'PICKEDUP' && !order.review && (
+                          <S.ReviewCreateButtonContainer>
+                            <S.ReviewCreateButton
+                              onPress={() =>
+                                navigation.navigate('Detail', {
+                                  screen: 'Review',
+                                  params: {
+                                    orderId: order.ordersId,
+                                    marketName: order.marketName,
+                                    reviewContents: order.products,
+                                  },
+                                })
+                              }>
+                              <S.ReviewCreateButtonText>
+                                리뷰 작성
+                              </S.ReviewCreateButtonText>
+                            </S.ReviewCreateButton>
+                          </S.ReviewCreateButtonContainer>
+                        )}
                         <S.OrderDetailButtonContainer>
                           <S.OrderDetailButton
                             onPress={() =>

--- a/src/components/review/RaitingStarts.style.tsx
+++ b/src/components/review/RaitingStarts.style.tsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/native';
+
+const S = {
+  Container: styled.View`
+    display: flex;
+    flex-direction: row;
+    padding: 8px;
+    justify-content: center;
+    align-items: center;
+  `,
+};
+
+export default S;

--- a/src/components/review/RatingStarts.tsx
+++ b/src/components/review/RatingStarts.tsx
@@ -1,0 +1,27 @@
+import React, {useState} from 'react';
+import {View, StyleSheet, TouchableOpacity} from 'react-native';
+import S from './RaitingStarts.style';
+import Icon from 'react-native-vector-icons/AntDesign';
+
+type RatingStarsProps = {
+  rating: number;
+  setRating: (rating: number) => void;
+};
+
+const RatingStars = ({rating, setRating}: RatingStarsProps) => {
+  return (
+    <S.Container>
+      {[1, 2, 3, 4, 5].map(value => (
+        <TouchableOpacity key={value} onPress={() => setRating(value)}>
+          <Icon
+            name={value <= rating ? 'star' : 'staro'}
+            size={42}
+            color="#FFD700"
+          />
+        </TouchableOpacity>
+      ))}
+    </S.Container>
+  );
+};
+
+export default RatingStars;

--- a/src/components/review/RatingStarts.tsx
+++ b/src/components/review/RatingStarts.tsx
@@ -15,7 +15,7 @@ const RatingStars = ({rating, setRating}: RatingStarsProps) => {
         <TouchableOpacity key={value} onPress={() => setRating(value)}>
           <Icon
             name={value <= rating ? 'star' : 'staro'}
-            size={42}
+            size={48}
             color="#FFD700"
           />
         </TouchableOpacity>

--- a/src/components/review/RatingStarts.tsx
+++ b/src/components/review/RatingStarts.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
-import {View, StyleSheet, TouchableOpacity} from 'react-native';
+import React from 'react';
+import {TouchableOpacity} from 'react-native';
 import S from './RaitingStarts.style';
 import Icon from 'react-native-vector-icons/AntDesign';
 

--- a/src/components/review/UploadedPicture.style.tsx
+++ b/src/components/review/UploadedPicture.style.tsx
@@ -21,7 +21,7 @@ const S = {
     margin-right: 8px;
   `,
 
-  UploadedImage: styled.View`
+  UploadedImageWrapper: styled.View`
     display: flex;
     gap: 8px;
     justify-content: center;
@@ -32,6 +32,10 @@ const S = {
     border-color: ${props => props.theme.colors.tertiaryDisabled};
     border-radius: 8px;
     margin-right: 8px;
+  `,
+  UploadedImage: styled.Image`
+    width: 100%;
+    height: 100%;
   `,
   ImageUploadText: styled.Text`
     ${({theme}) => theme.fonts.body2};

--- a/src/components/review/UploadedPicture.style.tsx
+++ b/src/components/review/UploadedPicture.style.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/native';
+
+const S = {
+  Container: styled.ScrollView`
+    display: flex;
+    flex-direction: row;
+    flex: 1;
+
+    width: 100%;
+  `,
+  ImageUploadButton: styled.TouchableOpacity`
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    align-items: center;
+    width: 100px;
+    height: 100px;
+    border: 1px solid;
+    border-color: ${props => props.theme.colors.tertiaryDisabled};
+    border-radius: 8px;
+    margin-right: 8px;
+  `,
+
+  UploadedImage: styled.View`
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    align-items: center;
+    width: 100px;
+    height: 100px;
+    border: 1px solid;
+    border-color: ${props => props.theme.colors.tertiaryDisabled};
+    border-radius: 8px;
+    margin-right: 8px;
+  `,
+  ImageUploadText: styled.Text`
+    ${({theme}) => theme.fonts.body2};
+    color: ${props => props.theme.colors.tertiary};
+    font-weight: 400;
+  `,
+};
+
+export default S;

--- a/src/components/review/UplodedPicture.tsx
+++ b/src/components/review/UplodedPicture.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import S from './UploadedPicture.style';
 import Icon from 'react-native-vector-icons/SimpleLineIcons';
-import {Image} from 'react-native';
-import {useReadReviewListForMarket} from '@/apis/review';
 
 type UploadedPictureProps = {
   imageUrls?: string[];
@@ -22,13 +20,9 @@ const UploadedPicture = ({imageUrls, setImageUrls}: UploadedPictureProps) => {
       {imageUrls &&
         imageUrls.length > 0 &&
         imageUrls.map(url => (
-          <S.UploadedImage key={url}>
-            <Image
-              source={{uri: url}}
-              style={{width: '100%', height: '100%'}}
-              resizeMode="cover"
-            />
-          </S.UploadedImage>
+          <S.UploadedImageWrapper key={url}>
+            <S.UploadedImage source={{uri: url}} resizeMode="cover" />
+          </S.UploadedImageWrapper>
         ))}
     </S.Container>
   );

--- a/src/components/review/UplodedPicture.tsx
+++ b/src/components/review/UplodedPicture.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import S from './UploadedPicture.style';
+import Icon from 'react-native-vector-icons/SimpleLineIcons';
+import {Image} from 'react-native';
+import {useReadReviewListForMarket} from '@/apis/review';
+
+type UploadedPictureProps = {
+  imageUrls?: string[];
+  setImageUrls: () => void;
+};
+
+const UploadedPicture = ({imageUrls, setImageUrls}: UploadedPictureProps) => {
+  return (
+    <S.Container
+      horizontal
+      pagingEnabled
+      showsHorizontalScrollIndicator={false}>
+      <S.ImageUploadButton onPress={setImageUrls}>
+        <Icon name={'camera'} size={40} />
+        <S.ImageUploadText>사진 {imageUrls?.length ?? 0}/5</S.ImageUploadText>
+      </S.ImageUploadButton>
+      {imageUrls &&
+        imageUrls.length > 0 &&
+        imageUrls.map(url => (
+          <S.UploadedImage key={url}>
+            <Image
+              source={{uri: url}}
+              style={{width: '100%', height: '100%'}}
+              resizeMode="cover"
+            />
+          </S.UploadedImage>
+        ))}
+    </S.Container>
+  );
+};
+
+export default UploadedPicture;

--- a/src/navigation/DetailNavigator.tsx
+++ b/src/navigation/DetailNavigator.tsx
@@ -16,6 +16,7 @@ import PaymentScreen from '@/screens/PaymentScreen';
 import {DetailStackParamList} from '@/types/StackNavigationType';
 import {View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import ReviewScreen from '@/screens/ReviewScreen';
 
 const Stack = createStackNavigator<DetailStackParamList>();
 
@@ -38,6 +39,11 @@ const orderDoneScreenOptions: StackNavigationOptions = {
   ...screenOptions,
   headerTitle: () => <HeaderTitle title="주문 완료" />,
   headerLeft: () => null,
+};
+
+const reviewScreenOptions: StackNavigationOptions = {
+  ...screenOptions,
+  headerTitle: () => <HeaderTitle title="리뷰 작성" />,
 };
 
 const DetailNavigator = () => {
@@ -70,6 +76,11 @@ const DetailNavigator = () => {
           name="OrderDetail"
           component={OrderDetailScreen}
           options={orderDetailScreenOptions}
+        />
+        <Stack.Screen
+          name="Review"
+          component={ReviewScreen}
+          options={reviewScreenOptions}
         />
       </Stack.Navigator>
     </View>

--- a/src/screens/ReviewScreen/ReviewScreen.style.tsx
+++ b/src/screens/ReviewScreen/ReviewScreen.style.tsx
@@ -1,0 +1,55 @@
+import styled from '@emotion/native';
+
+const S = {
+  ReviewScreenContainer: styled.View`
+    flex: 1;
+    background-color: white;
+    padding: 16px 16px;
+  `,
+  ReviewRequestTextContainer: styled.View`
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 24px;
+  `,
+  ReviewRequsetText: styled.Text`
+    ${({theme}) => theme.fonts.subtitle1};
+    color: ${props => props.theme.colors.primary};
+    font-weight: 700;
+  `,
+  ContentInformationText: styled.Text`
+    ${({theme}) => theme.fonts.body1};
+    color: ${props => props.theme.colors.tertiary};
+    font-weight: 700;
+  `,
+
+  MarketName: styled.Text`
+    ${({theme}) => theme.fonts.h5};
+    color: ${props => props.theme.colors.tertiary};
+    font-weight: 700;
+  `,
+
+  ReviewContentContainer: styled.View`
+    display: flex;
+    margin: 16px 0px;
+    gap: 12px;
+  `,
+  TextRowWrapper: styled.View`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  `,
+
+  ContentDescription: styled.Text`
+    ${({theme}) => theme.fonts.body1};
+    color: ${props => props.theme.colors.tertiary};
+  `,
+
+  ReviewInputContainer: styled.View`
+    display: flex;
+    gap: 16px;
+    height: 312px;
+  `,
+};
+
+export default S;

--- a/src/screens/ReviewScreen/ReviewScreen.style.tsx
+++ b/src/screens/ReviewScreen/ReviewScreen.style.tsx
@@ -48,7 +48,7 @@ const S = {
   ReviewInputContainer: styled.View`
     display: flex;
     gap: 16px;
-    height: 312px;
+    height: 256px;
   `,
 };
 

--- a/src/screens/ReviewScreen/index.tsx
+++ b/src/screens/ReviewScreen/index.tsx
@@ -1,5 +1,4 @@
 import React, {useState} from 'react';
-import {View, Text} from 'react-native';
 import RatingStars from '@/components/review/RatingStarts';
 import S from './ReviewScreen.style';
 import {StackScreenProps} from '@react-navigation/stack';
@@ -90,10 +89,6 @@ const ReviewScreen = ({navigation, route}: ReviewScreenProps) => {
         <RatingStars rating={rating} setRating={setRating} />
         <TextInput
           placeholder="반찬에 대한 리뷰를 남겨주세요!"
-          style={{height: 100}}
-          inputStyle={{
-            height: 100,
-          }}
           value={review}
           onChange={e => setReview(e.nativeEvent.text)}
         />

--- a/src/screens/ReviewScreen/index.tsx
+++ b/src/screens/ReviewScreen/index.tsx
@@ -1,0 +1,114 @@
+import React, {useState} from 'react';
+import {View, Text} from 'react-native';
+import RatingStars from '@/components/review/RatingStarts';
+import S from './ReviewScreen.style';
+import {StackScreenProps} from '@react-navigation/stack';
+import {DetailStackParamList} from '@/types/StackNavigationType';
+import {BottomButton} from '@/components/common';
+import TextInput from '@/components/common/TextInput/TextInput';
+import UploadedPicture from '@/components/review/UplodedPicture';
+import {
+  useCreateReviewMutation,
+  useUploadReviewImageMutation,
+} from '@/apis/review';
+import {pickImage} from '@/utils/image-picker';
+type ReviewScreenProps = StackScreenProps<DetailStackParamList, 'Review'>;
+import {Alert} from 'react-native';
+
+const ReviewScreen = ({navigation, route}: ReviewScreenProps) => {
+  const {orderId, reviewContents, marketName} = route.params;
+  const [rating, setRating] = useState<number>(5);
+  const [review, setReview] = useState<string>('');
+  const {mutateAsync: reviewImageUploadMutate} = useUploadReviewImageMutation();
+  const {mutate: reviewCreateMutate} = useCreateReviewMutation(orderId);
+  const [reviewImageUrls, setReviewImageUrls] = useState<string[]>([]);
+
+  const handleImageUpload = async () => {
+    const res = await pickImage();
+    if (!res) {
+      console.error('pickImage Error: no image');
+      Alert.alert('이미지를 불러오지 못했습니다.');
+      return;
+    }
+
+    const formdata = new FormData();
+
+    formdata.append('updateImage', {
+      name: res.split('/').pop(),
+      type: `image/jpeg`,
+      uri: res,
+    });
+
+    const s3Url = await reviewImageUploadMutate(formdata);
+    console.log('asdfasdfsdaf: ', s3Url);
+    if (!s3Url) {
+      console.error('uploadProductImage Error: no s3Url');
+      Alert.alert('이미지를 업로드하지 못했습니다.');
+      return;
+    }
+    setReviewImageUrls(prev => [...prev, s3Url]);
+  };
+
+  const handleReviewCreateMutate = () => {
+    reviewCreateMutate(
+      {rating, imageUrls: reviewImageUrls, content: review},
+      {
+        onSuccess: () => {
+          Alert.alert('리뷰 작성이 완료되었어요!');
+          navigation.navigate('Home', {screen: 'Feed'});
+        },
+        onError: () => {
+          // FIXME: 에러 핸들링
+          Alert.alert('리뷰 작성에 실패했어요. 다시 시도해주세요!');
+        },
+      },
+    );
+  };
+
+  return (
+    <S.ReviewScreenContainer>
+      <S.ReviewRequestTextContainer>
+        <S.ReviewRequsetText>
+          주문에 대한 리뷰를 작성해주세요!
+        </S.ReviewRequsetText>
+      </S.ReviewRequestTextContainer>
+      <S.MarketName>{marketName}</S.MarketName>
+      <S.ReviewContentContainer>
+        <S.ContentInformationText>주문 정보 </S.ContentInformationText>
+        {reviewContents.map(content => (
+          <S.TextRowWrapper key={content.id}>
+            <S.ContentDescription>
+              {content.name} {content.count}개
+            </S.ContentDescription>
+            <S.ContentDescription>
+              {(content.discountPrice * content.count).toLocaleString()}원
+            </S.ContentDescription>
+          </S.TextRowWrapper>
+        ))}
+      </S.ReviewContentContainer>
+      <S.ReviewInputContainer>
+        <RatingStars rating={rating} setRating={setRating} />
+        <TextInput
+          placeholder="반찬에 대한 리뷰를 남겨주세요!"
+          style={{height: 100}}
+          inputStyle={{
+            height: 100,
+          }}
+          value={review}
+          onChange={e => setReview(e.nativeEvent.text)}
+        />
+        <UploadedPicture
+          imageUrls={reviewImageUrls}
+          setImageUrls={handleImageUpload}
+        />
+      </S.ReviewInputContainer>
+      <BottomButton
+        disabled={!review || review.length === 0}
+        onPress={handleReviewCreateMutate}>
+        리뷰 작성하기
+      </BottomButton>
+    </S.ReviewScreenContainer>
+  );
+};
+
+export default ReviewScreen;

--- a/src/types/OrderType.ts
+++ b/src/types/OrderType.ts
@@ -18,6 +18,7 @@ export type OrderType = {
     | 'PICKEDUP_OR_CANCELED';
   customerRequest: string;
   products: (ProductType & {count: number})[];
+  review: boolean;
 };
 
 export type OrderDetailType = OrderType & {

--- a/src/types/StackNavigationType.ts
+++ b/src/types/StackNavigationType.ts
@@ -1,5 +1,6 @@
 import {ParamListBase} from '@react-navigation/native';
 import {OrderType} from './OrderType';
+import {ProductType} from './ProductType';
 
 type StackParamType<T> = {
   screen?: keyof T;
@@ -29,6 +30,11 @@ export interface DetailStackParamList extends ParamListBase {
   };
   OrderDetail: {
     ordersId: string;
+  };
+  Review: {
+    orderId: string;
+    marketName: string;
+    reviewContents: (ProductType & {count: number})[];
   };
 }
 

--- a/src/utils/image-picker.ts
+++ b/src/utils/image-picker.ts
@@ -1,0 +1,27 @@
+import {
+  ImageLibraryOptions,
+  launchImageLibrary,
+} from 'react-native-image-picker';
+
+export async function pickImage(
+  options: ImageLibraryOptions = {mediaType: 'photo'},
+): Promise<string> {
+  const imagePickerResUri = await launchImageLibrary(options, res => {
+    if (res.didCancel || !res.assets) {
+      return;
+    }
+
+    if (res.errorCode) {
+      console.log(res.errorMessage);
+      return;
+    }
+
+    return res;
+  });
+
+  if (!imagePickerResUri || !imagePickerResUri.assets) {
+    return '';
+  }
+
+  return imagePickerResUri.assets[0].uri ?? '';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4403,6 +4403,7 @@ __metadata:
     react-native-geolocation-service: ^5.3.1
     react-native-gesture-handler: ^2.18.1
     react-native-image-modal: ^3.0.13
+    react-native-image-picker: ^8.2.0
     react-native-linear-gradient: ^2.8.3
     react-native-naver-map: "https://github.com/zerocho/react-native-naver-map"
     react-native-paper: ^5.12.5
@@ -10180,6 +10181,16 @@ __metadata:
   version: 3.0.13
   resolution: "react-native-image-modal@npm:3.0.13"
   checksum: 8a1aa36f73039f4d9dfb546049ebb88815c33763efc511cdc962bd29429fb7fe977189e0f53842857ce5dd12c565fe88d0c98791a9bc575827678720114d2d33
+  languageName: node
+  linkType: hard
+
+"react-native-image-picker@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "react-native-image-picker@npm:8.2.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: d261d4f0571b771c5d2d8a1d5c129743a4993318a454e5bf7850db0fa452d4d5da2215a2f2af3879cd38211b864b3ba77d1d09255ff1f43112b3dcf985d6c233
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #136 

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용
- react-native-image-picker 설치 및 사용(사장앱과 동일)
- 별점 컴포넌트 구현
- 사진 업로드 컴포넌트 구현
- 리뷰 페이지 제작
- 주문 상세 페이지에서 navigate


<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)
<p align="center">
  <img src="https://github.com/user-attachments/assets/c63b6779-1dff-48a1-b986-2aaf9d5794dd" width="45%">
  <img src="https://github.com/user-attachments/assets/8d587078-236e-4cd6-8f11-3f5d0f21f7b6" width="45%">
</p>

주문 목록에서 /customer/orders respons에 `review: boolean` 타입 추가
review: false && 주문이 종료되었을 때(orderStatus === PICKED_UP) 시 리뷰 작성 버튼 조건부 렌더링 

리뷰 작성하기 버튼은 TextInput 박스 입력 string만 가지고 disabled 걸었습니다.

## 💬리뷰 요구사항(선택)

TextInput 컴포넌트 height를 억지로 늘렸다가 다시 줄였습니다.
외부에서 주입할 수 있는 방법이 현재 있나요..?

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

#### TODO
- 고객 본인이 작성한 리뷰 조회 페이지
- 고객 리뷰 수정 기능
- 고객 리뷰 작성 중 s3 업로드 image 삭제(api 필요)
- 사장님 리뷰 조회 페이지 디자인 수정
<p >
  <img src="https://github.com/user-attachments/assets/eab124a6-145c-4b69-8748-68ff5d5a94b2" width="45%">
</p>
