### PR TITLE
feat: 고객 자신 리뷰 조회 기능 추가

### DIFF
--- a/src/apis/review/client.ts
+++ b/src/apis/review/client.ts
@@ -1,8 +1,9 @@
 import {
   CreateReviewRequest,
   UpdateReviewRequest,
-  ReadReviewRequest,
+  ReadMarketReviewRequest,
   ReadReviewResponse,
+  ReadCustomerReviewRequest,
 } from './model';
 
 import apiClient from '../ApiClient';
@@ -11,11 +12,38 @@ import CustomError from '../CustomError';
 const entity = 'customer/review';
 
 export const getReviewListForMarket = async (
-  req: ReadReviewRequest,
+  req: ReadMarketReviewRequest,
 ): Promise<ReadReviewResponse> => {
   try {
     const res = await apiClient.get<ReadReviewResponse>(
       `${entity}/market/${req.marketId}`,
+      {
+        params: {
+          cursorId: req.cursorId,
+          size: req.size,
+        },
+      },
+    );
+    if (res) {
+      return res;
+    }
+    return {
+      reviews: [],
+      reviewNum: 0,
+      averageRating: 0,
+      hasNext: false,
+    };
+  } catch (error) {
+    throw new CustomError(error);
+  }
+};
+
+export const getReviewListForCustomer = async (
+  req: ReadCustomerReviewRequest,
+): Promise<ReadReviewResponse> => {
+  try {
+    const res = await apiClient.get<ReadReviewResponse>(
+      `${entity}/market/${req.memberId}`,
       {
         params: {
           cursorId: req.cursorId,

--- a/src/apis/review/client.ts
+++ b/src/apis/review/client.ts
@@ -2,8 +2,9 @@ import {
   CreateReviewRequest,
   UpdateReviewRequest,
   ReadMarketReviewRequest,
-  ReadReviewResponse,
+  ReadMarketReviewResponse,
   ReadCustomerReviewRequest,
+  ReadCustomerReviewResponse,
 } from './model';
 
 import apiClient from '../ApiClient';
@@ -13,9 +14,9 @@ const entity = 'customer/review';
 
 export const getReviewListForMarket = async (
   req: ReadMarketReviewRequest,
-): Promise<ReadReviewResponse> => {
+): Promise<ReadMarketReviewResponse> => {
   try {
-    const res = await apiClient.get<ReadReviewResponse>(
+    const res = await apiClient.get<ReadMarketReviewResponse>(
       `${entity}/market/${req.marketId}`,
       {
         params: {
@@ -40,9 +41,9 @@ export const getReviewListForMarket = async (
 
 export const getReviewListForCustomer = async (
   req: ReadCustomerReviewRequest,
-): Promise<ReadReviewResponse> => {
+): Promise<ReadCustomerReviewResponse> => {
   try {
-    const res = await apiClient.get<ReadReviewResponse>(
+    const res = await apiClient.get<ReadCustomerReviewResponse>(
       `${entity}/${req.memberId}`,
       {
         params: {

--- a/src/apis/review/client.ts
+++ b/src/apis/review/client.ts
@@ -43,7 +43,7 @@ export const getReviewListForCustomer = async (
 ): Promise<ReadReviewResponse> => {
   try {
     const res = await apiClient.get<ReadReviewResponse>(
-      `${entity}/market/${req.memberId}`,
+      `${entity}/${req.memberId}`,
       {
         params: {
           cursorId: req.cursorId,

--- a/src/apis/review/model.ts
+++ b/src/apis/review/model.ts
@@ -1,7 +1,13 @@
 import {ReviewInfo} from '@/types/Review';
 
-export type ReadReviewRequest = {
+export type ReadMarketReviewRequest = {
   marketId: number;
+  cursorId: number;
+  size: number;
+};
+
+export type ReadCustomerReviewRequest = {
+  memberId: number;
   cursorId: number;
   size: number;
 };

--- a/src/apis/review/model.ts
+++ b/src/apis/review/model.ts
@@ -1,4 +1,4 @@
-import {ReviewInfo} from '@/types/Review';
+import {CustomerReviewInfo, MarketReviewInfo} from '@/types/Review';
 
 export type ReadMarketReviewRequest = {
   marketId: number;
@@ -12,8 +12,15 @@ export type ReadCustomerReviewRequest = {
   size: number;
 };
 
-export type ReadReviewResponse = {
-  reviews: ReviewInfo[];
+export type ReadMarketReviewResponse = {
+  reviews: MarketReviewInfo[];
+  reviewNum: number;
+  averageRating: number;
+  hasNext: boolean;
+};
+
+export type ReadCustomerReviewResponse = {
+  reviews: CustomerReviewInfo[];
   reviewNum: number;
   averageRating: number;
   hasNext: boolean;

--- a/src/apis/review/query.ts
+++ b/src/apis/review/query.ts
@@ -4,20 +4,36 @@ import {
   updateReview,
   uploadReviewImage,
   getReviewListForMarket,
+  getReviewListForCustomer,
 } from './client';
 import {
   CreateReviewRequest,
-  ReadReviewRequest,
+  ReadMarketReviewRequest,
   UpdateReviewRequest,
+  ReadCustomerReviewRequest,
 } from './model';
 
 export const useReadReviewListForMarket = (
-  marketId: ReadReviewRequest['marketId'],
+  marketId: ReadMarketReviewRequest['marketId'],
 ) =>
   useInfiniteQuery({
     queryKey: ['readReviewListForMarket', marketId],
     queryFn: ({pageParam = 0}) =>
       getReviewListForMarket({marketId, cursorId: pageParam, size: 5}),
+    initialPageParam: 0,
+    getNextPageParam: lastPage =>
+      lastPage.hasNext
+        ? lastPage.reviews[lastPage.reviews.length - 1].id
+        : undefined,
+  });
+
+export const useReadReviewListForCustomer = (
+  memberId: ReadCustomerReviewRequest['memberId'],
+) =>
+  useInfiniteQuery({
+    queryKey: ['readReviewListForCustomer', memberId],
+    queryFn: ({pageParam = 0}) =>
+      getReviewListForCustomer({memberId, cursorId: pageParam, size: 5}),
     initialPageParam: 0,
     getNextPageParam: lastPage =>
       lastPage.hasNext

--- a/src/components/common/ListBox.tsx
+++ b/src/components/common/ListBox.tsx
@@ -17,25 +17,27 @@ const ListBox = ({items}: ListBoxProps) => {
         const isFirst = index === 0;
         const isLast = index === items.length - 1;
         return (
-          <S.ListItem key={index} isFirst={isFirst} isLast={isLast}>
+          <S.ListItem
+            key={`${index}-${item.label}`}
+            isFirst={isFirst}
+            isLast={isLast}>
             <S.ItemLabel>{item.label}</S.ItemLabel>
-            {item.value &&
-              (item.onPress ? (
-                <NavigationTextButton
-                  text={item.value}
-                  onPress={item.onPress}
-                  fontColor="#888"
-                  fontSize="16px"
-                  iconSize={20}
-                />
-              ) : (
-                <NavigationTextButton
-                  text={item.value}
-                  fontColor="#888"
-                  fontSize="16px"
-                  isNotice={false}
-                />
-              ))}
+            {item.onPress ? (
+              <NavigationTextButton
+                text={item.value ? item.value : ''}
+                onPress={item.onPress}
+                fontColor="#888"
+                fontSize="16px"
+                iconSize={20}
+              />
+            ) : (
+              <NavigationTextButton
+                text={item.value ? item.value : ''}
+                fontColor="#888"
+                fontSize="16px"
+                isNotice={false}
+              />
+            )}
           </S.ListItem>
         );
       })}

--- a/src/components/common/NavigateTextButton.tsx
+++ b/src/components/common/NavigateTextButton.tsx
@@ -3,7 +3,7 @@ import S from './NavigateTextButton.style';
 import Icon from 'react-native-vector-icons/AntDesign';
 
 type NavigationTextButtonProps = {
-  text: string;
+  text?: string;
   onPress?: () => void;
   fontColor?: string;
   fontSize?: string;
@@ -22,9 +22,11 @@ const NavigationTextButton = ({
   return (
     <S.TouchableButtonContainer onPress={onPress} disabled={!onPress}>
       <S.TouchableWrapper>
-        <S.NoticeText fontColor={fontColor} fontSize={fontSize}>
-          {text}
-        </S.NoticeText>
+        {text && (
+          <S.NoticeText fontColor={fontColor} fontSize={fontSize}>
+            {text}
+          </S.NoticeText>
+        )}
         {isNotice && <Icon name="right" size={iconSize} color={fontColor} />}
       </S.TouchableWrapper>
     </S.TouchableButtonContainer>

--- a/src/components/common/customerReview/CustomerReviewCard.style.tsx
+++ b/src/components/common/customerReview/CustomerReviewCard.style.tsx
@@ -1,0 +1,102 @@
+import styled from '@emotion/native';
+
+const S = {
+  Container: styled.View`
+    background-color: white;
+    margin-bottom: 20px;
+  `,
+  CustomerNameText: styled.Text`
+    ${props => props.theme.fonts.titleMedium};
+    color: black;
+    font-family: Pretendard;
+    font-weight: 600;
+    margin-right: 2px;
+  `,
+
+  ReviewHeaderWrapper: styled.View`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 8px;
+    justify-content: space-between;
+  `,
+  ReviewLeftToMarket: styled.TouchableOpacity`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  `,
+  ReviewHeaderLeft: styled.View`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 2px;
+  `,
+  ReviewRating: styled.View`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 2px;
+    padding-left: 4px;
+  `,
+  ReviewCreatedText: styled.Text`
+    ${({theme}) => theme.fonts.caption};
+    color: ${props => props.theme.colors.tertiaryDisabled};
+    font-weight: 400;
+  `,
+  OrderInfoWrapper: styled.View`
+    display: flex;
+    align-items: flex-start;
+    width: auto;
+    margin: 16px 0px;
+  `,
+
+  OrderInfoTextWrapper: styled.View`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid ${props => props.theme.colors.primary};
+    border-radius: 10px;
+    padding: 2px 8px;
+  `,
+  OrderInfoText: styled.Text`
+    ${({theme}) => theme.fonts.body2};
+    color: ${props => props.theme.colors.tertiary};
+    font-weight: 600;
+  `,
+  CustomerReviewText: styled.Text`
+    ${({theme}) => theme.fonts.body1};
+    color: ${props => props.theme.colors.tertiary};
+  `,
+  ReviewCountText: styled.Text`
+    ${props => props.theme.fonts.titleMedium};
+    color: black;
+    font-family: Pretendard;
+    font-weight: 600;
+    padding-left: 2px;
+    margin-right: -14px;
+  `,
+
+  ImagesContainer: styled.ScrollView`
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    margin-top: 12px;
+    gap: 8px;
+  `,
+  ImageWrapper: styled.View`
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    align-items: center;
+    width: 128px;
+    height: 128px;
+    border-radius: 8px;
+  `,
+  Image: styled.Image`
+    width: 100%;
+    height: 100%;
+    border-radius: 8px;
+  `,
+};
+
+export default S;

--- a/src/components/common/customerReview/CustomerReviewCard.tsx
+++ b/src/components/common/customerReview/CustomerReviewCard.tsx
@@ -1,19 +1,23 @@
-import {MarketReviewInfo} from '@/types/Review';
+import {CustomerReviewInfo} from '@/types/Review';
 import React from 'react';
 import StarIcon from 'react-native-vector-icons/Fontisto';
-import S from './MarketReviewCard.style';
-import CustomImageModal from '../common/CustomImageModal';
+import CustomImageModal from '../CustomImageModal';
 import {format} from '@/utils/date';
-import MarketReviewReplyCard from './MarketReviewReplyCard';
+import MarketReviewReplyCard from '@/components/marketReview/MarketReviewReplyCard';
+import S from './CustomerReviewCard.style';
+import Icon from 'react-native-vector-icons/AntDesign';
+import theme from '@/context/theme';
 
-type MarketReviewCardProps = {
-  review: MarketReviewInfo;
+type CustomerReviewCardProps = {
+  review: CustomerReviewInfo;
+  onPress: (marketId: number) => void;
 };
 
-const MarketReviewCard = ({review}: MarketReviewCardProps) => {
+const CustomerReviewCard = ({review, onPress}: CustomerReviewCardProps) => {
   const {
     id,
-    name,
+    marketId,
+    marketName,
     content,
     rating,
     products,
@@ -25,16 +29,23 @@ const MarketReviewCard = ({review}: MarketReviewCardProps) => {
     <S.Container>
       <S.ReviewHeaderWrapper>
         <S.ReviewHeaderLeft>
-          <S.CustomerNameText>{name}님</S.CustomerNameText>
-          {Array.from({length: rating}).map((_, index) => (
-            <StarIcon key={index} name="star" color="#FFD700" size={12} />
-          ))}
+          <S.ReviewLeftToMarket
+            onPress={() => {
+              onPress(marketId);
+            }}>
+            <S.CustomerNameText>{marketName}</S.CustomerNameText>
+            <Icon name="right" size={16} color={theme.colors.tertiary} />
+          </S.ReviewLeftToMarket>
+          <S.ReviewRating>
+            {Array.from({length: rating}).map((_, index) => (
+              <StarIcon key={index} name="star" color="#FFD700" size={12} />
+            ))}
+          </S.ReviewRating>
         </S.ReviewHeaderLeft>
         <S.ReviewCreatedText>
           {format(createdAt, 'YYYY년 M월 D일')}
         </S.ReviewCreatedText>
       </S.ReviewHeaderWrapper>
-
       <S.CustomerReviewText>{content}</S.CustomerReviewText>
       <S.ImagesContainer
         horizontal
@@ -71,4 +82,4 @@ const MarketReviewCard = ({review}: MarketReviewCardProps) => {
   );
 };
 
-export default MarketReviewCard;
+export default CustomerReviewCard;

--- a/src/components/common/customerReview/index.ts
+++ b/src/components/common/customerReview/index.ts
@@ -1,0 +1,1 @@
+export {default as CustomerReviewCard} from './CustomerReviewCard';

--- a/src/navigation/DetailNavigator.tsx
+++ b/src/navigation/DetailNavigator.tsx
@@ -18,6 +18,7 @@ import {View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import ReviewCreateScreen from '@/screens/ReviewCreateScreen';
 import MarketReviewScreen from '@/screens/MarketReviewScreen';
+import CustomerReviewScreen from '@/screens/CustomerReviewScreen';
 
 const Stack = createStackNavigator<DetailStackParamList>();
 
@@ -49,6 +50,10 @@ const reviewCreateScreenOptions: StackNavigationOptions = {
 const marketReviewScreenOptions: StackNavigationOptions = {
   ...screenOptions,
   headerTitle: () => <HeaderTitle title="리뷰" />,
+};
+const customerReviewScreenOptions: StackNavigationOptions = {
+  ...screenOptions,
+  headerTitle: () => <HeaderTitle title="내가 쓴 리뷰" />,
 };
 
 const DetailNavigator = () => {
@@ -91,6 +96,11 @@ const DetailNavigator = () => {
           name="MarketReview"
           component={MarketReviewScreen}
           options={marketReviewScreenOptions}
+        />
+        <Stack.Screen
+          name="CustomerReview"
+          component={CustomerReviewScreen}
+          options={customerReviewScreenOptions}
         />
       </Stack.Navigator>
     </View>

--- a/src/navigation/DetailNavigator.tsx
+++ b/src/navigation/DetailNavigator.tsx
@@ -18,7 +18,6 @@ import {View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import ReviewCreateScreen from '@/screens/ReviewCreateScreen';
 import MarketReviewScreen from '@/screens/MarketReviewScreen';
-import CustomerReviewScreen from '@/screens/CustomerReviewScreen';
 
 const Stack = createStackNavigator<DetailStackParamList>();
 
@@ -50,10 +49,6 @@ const reviewCreateScreenOptions: StackNavigationOptions = {
 const marketReviewScreenOptions: StackNavigationOptions = {
   ...screenOptions,
   headerTitle: () => <HeaderTitle title="리뷰" />,
-};
-const customerReviewScreenOptions: StackNavigationOptions = {
-  ...screenOptions,
-  headerTitle: () => <HeaderTitle title="내가 쓴 리뷰" />,
 };
 
 const DetailNavigator = () => {
@@ -96,11 +91,6 @@ const DetailNavigator = () => {
           name="MarketReview"
           component={MarketReviewScreen}
           options={marketReviewScreenOptions}
-        />
-        <Stack.Screen
-          name="CustomerReview"
-          component={CustomerReviewScreen}
-          options={customerReviewScreenOptions}
         />
       </Stack.Navigator>
     </View>

--- a/src/navigation/MyPageNavigator.tsx
+++ b/src/navigation/MyPageNavigator.tsx
@@ -11,6 +11,7 @@ import MyPageScreen from '@/screens/MyPageScreen';
 import NoticePage from '@/screens/MyPageScreen/NoticePage';
 import PolicyPage from '@/screens/MyPageScreen/PolicyPage';
 import SettingScreen from '@/screens/SettingScreen';
+import CustomerReviewScreen from '@/screens/CustomerReviewScreen';
 
 import {MyPageStackParamList} from '@/types/StackNavigationType';
 
@@ -36,6 +37,10 @@ const settingScreenOptions: StackNavigationOptions = {
   headerTitle: () => <HeaderTitle title="설정" />,
 };
 
+const customerReviewScreenOptions: StackNavigationOptions = {
+  ...defaultOptions,
+  headerTitle: () => <HeaderTitle title="내 리뷰 조회" />,
+};
 const MyPageNavigator = () => {
   return (
     <Stack.Navigator
@@ -60,6 +65,11 @@ const MyPageNavigator = () => {
         name={'Policy'}
         component={PolicyPage}
         options={policyPageOptions}
+      />
+      <Stack.Screen
+        name="CustomerReview"
+        component={CustomerReviewScreen}
+        options={customerReviewScreenOptions}
       />
     </Stack.Navigator>
   );

--- a/src/screens/CustomerReviewScreen/CustomerReviewScreen.style.tsx
+++ b/src/screens/CustomerReviewScreen/CustomerReviewScreen.style.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/native';
+
+const S = {
+  Container: styled.View`
+    background-color: white;
+    padding: 16px;
+    flex: 1;
+    height: 100%;
+  `,
+  LastIndicatorItem: styled.View`
+    padding: 16px;
+
+    justify-content: center;
+    align-items: center;
+  `,
+};
+
+export default S;

--- a/src/screens/CustomerReviewScreen/index.tsx
+++ b/src/screens/CustomerReviewScreen/index.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback} from 'react';
 import {View, FlatList, RefreshControl} from 'react-native';
 import {StackScreenProps} from '@react-navigation/stack';
-import {DetailStackParamList} from '@/types/StackNavigationType';
+import {MyPageStackParamList} from '@/types/StackNavigationType';
 import {useReadReviewListForCustomer} from '@/apis/review';
 import usePullDownRefresh from '@/hooks/usePullDownRefresh';
 import S from './CustomerReviewScreen.style';
@@ -9,7 +9,7 @@ import {CustomerReviewCard} from '@/components/common/customerReview';
 import {ActivityIndicator} from 'react-native-paper';
 
 type CustomerReviewScreenProps = StackScreenProps<
-  DetailStackParamList,
+  MyPageStackParamList,
   'CustomerReview'
 >;
 

--- a/src/screens/CustomerReviewScreen/index.tsx
+++ b/src/screens/CustomerReviewScreen/index.tsx
@@ -1,11 +1,11 @@
 import React, {useCallback} from 'react';
-import {View, FlatList, RefreshControl, Text} from 'react-native';
+import {View, FlatList, RefreshControl} from 'react-native';
 import {StackScreenProps} from '@react-navigation/stack';
 import {DetailStackParamList} from '@/types/StackNavigationType';
 import {useReadReviewListForCustomer} from '@/apis/review';
 import usePullDownRefresh from '@/hooks/usePullDownRefresh';
 import S from './CustomerReviewScreen.style';
-import MarketReviewCard from '@/components/marketReview/MarketReviewCard';
+import {CustomerReviewCard} from '@/components/common/customerReview';
 import {ActivityIndicator} from 'react-native-paper';
 
 type CustomerReviewScreenProps = StackScreenProps<
@@ -46,6 +46,15 @@ const CustomerReviewScreen = ({
       </View>
     );
   }
+
+  const navigateMarketDetail = (marketId: number) => {
+    navigation.navigate('Detail', {
+      screen: 'MarketDetail',
+      params: {
+        marketId: marketId,
+      },
+    });
+  };
   return (
     <S.Container>
       <FlatList
@@ -53,9 +62,11 @@ const CustomerReviewScreen = ({
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
-        keyExtractor={(item, index) => `${item.id}-${index}-${item.name}`}
+        keyExtractor={(item, index) => `${item.id}-${index}`}
         renderItem={({item}) => {
-          return <MarketReviewCard review={item} />;
+          return (
+            <CustomerReviewCard review={item} onPress={navigateMarketDetail} />
+          );
         }}
         ListFooterComponent={
           isFetchingNextPage ? (

--- a/src/screens/CustomerReviewScreen/index.tsx
+++ b/src/screens/CustomerReviewScreen/index.tsx
@@ -1,17 +1,22 @@
 import React, {useCallback} from 'react';
-import {View, FlatList, RefreshControl} from 'react-native';
+import {View, FlatList, RefreshControl, Text} from 'react-native';
 import {StackScreenProps} from '@react-navigation/stack';
 import {DetailStackParamList} from '@/types/StackNavigationType';
-import {useReadReviewListForMarket} from '@/apis/review';
+import {useReadReviewListForCustomer} from '@/apis/review';
 import usePullDownRefresh from '@/hooks/usePullDownRefresh';
-import S from './MarketReviewScreen.style';
+import S from './CustomerReviewScreen.style';
 import MarketReviewCard from '@/components/marketReview/MarketReviewCard';
 import {ActivityIndicator} from 'react-native-paper';
-type MarketReviewScreenProps = StackScreenProps<
+
+type CustomerReviewScreenProps = StackScreenProps<
   DetailStackParamList,
-  'MarketReview'
+  'CustomerReview'
 >;
-const MarketReviewScreen = ({route}: MarketReviewScreenProps) => {
+
+const CustomerReviewScreen = ({
+  navigation,
+  route,
+}: CustomerReviewScreenProps) => {
   const {
     data: reviewList,
     refetch,
@@ -19,7 +24,8 @@ const MarketReviewScreen = ({route}: MarketReviewScreenProps) => {
     isFetchingNextPage,
     hasNextPage,
     fetchNextPage,
-  } = useReadReviewListForMarket(route.params.marketId);
+  } = useReadReviewListForCustomer(route.params.memberId);
+
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
@@ -40,7 +46,6 @@ const MarketReviewScreen = ({route}: MarketReviewScreenProps) => {
       </View>
     );
   }
-
   return (
     <S.Container>
       <FlatList
@@ -66,4 +71,4 @@ const MarketReviewScreen = ({route}: MarketReviewScreenProps) => {
   );
 };
 
-export default MarketReviewScreen;
+export default CustomerReviewScreen;

--- a/src/screens/MyPageScreen/UserMyPage.tsx
+++ b/src/screens/MyPageScreen/UserMyPage.tsx
@@ -55,6 +55,14 @@ const UserMyPage = ({profile, refreshing, onRefresh}: UserMyPageProps) => {
             label: '소셜 로그인',
             value: convertOAuthProviderToKorean(profile.provider),
           },
+          {
+            label: '내가 쓴 리뷰',
+            onPress: () =>
+              navigation.navigate('Detail', {
+                screen: 'CustomerReview',
+                params: {memberId: profile.id},
+              }),
+          },
         ]}
       />
       <S.NoticeSection>

--- a/src/screens/MyPageScreen/UserMyPage.tsx
+++ b/src/screens/MyPageScreen/UserMyPage.tsx
@@ -57,6 +57,7 @@ const UserMyPage = ({profile, refreshing, onRefresh}: UserMyPageProps) => {
           },
           {
             label: '내가 쓴 리뷰',
+            value: '조회',
             onPress: () =>
               navigation.navigate('Detail', {
                 screen: 'CustomerReview',

--- a/src/screens/MyPageScreen/UserMyPage.tsx
+++ b/src/screens/MyPageScreen/UserMyPage.tsx
@@ -59,7 +59,7 @@ const UserMyPage = ({profile, refreshing, onRefresh}: UserMyPageProps) => {
             label: '내가 쓴 리뷰',
             value: '조회',
             onPress: () =>
-              navigation.navigate('Detail', {
+              navigation.navigate('MyPageRoot', {
                 screen: 'CustomerReview',
                 params: {memberId: profile.id},
               }),

--- a/src/types/Review.ts
+++ b/src/types/Review.ts
@@ -1,6 +1,22 @@
-export type ReviewInfo = {
+export type MarketReviewInfo = {
   id: number;
   name: string;
+  content: string;
+  rating: number;
+  products: string[];
+  createdAt: string;
+  imageUrls: string[];
+  reviewReplies: {
+    reviewReplyId: number;
+    createAt: string;
+    content: string;
+  };
+};
+
+export type CustomerReviewInfo = {
+  id: number;
+  marketId: number;
+  marketName: number;
   content: string;
   rating: number;
   products: string[];

--- a/src/types/StackNavigationType.ts
+++ b/src/types/StackNavigationType.ts
@@ -40,6 +40,9 @@ export interface DetailStackParamList extends ParamListBase {
   MarketReview: {
     marketId: number;
   };
+  CustomerReview: {
+    memberId: number;
+  };
 }
 
 export interface FeedStackParamList extends ParamListBase {

--- a/src/types/StackNavigationType.ts
+++ b/src/types/StackNavigationType.ts
@@ -40,9 +40,6 @@ export interface DetailStackParamList extends ParamListBase {
   MarketReview: {
     marketId: number;
   };
-  CustomerReview: {
-    memberId: number;
-  };
 }
 
 export interface FeedStackParamList extends ParamListBase {
@@ -66,6 +63,9 @@ export interface MyPageStackParamList extends ParamListBase {
   Setting: undefined;
   Notice: undefined;
   Policy: undefined;
+  CustomerReview: {
+    memberId: number;
+  };
 }
 
 export interface RootStackParamList extends ParamListBase {


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용
- 고객 본인의 리뷰 조회 페이지 
- 마이페이지 내에서 리다이렉트 버튼 추가

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)
<div>
  <img src="https://github.com/user-attachments/assets/3b0cdb6f-dbb8-4e98-93d4-1c1f8fa6eb43" width="45%">
<img src="https://github.com/user-attachments/assets/d4c3ef5e-a2d9-4c52-9446-96f2e0934529" width="45%">

</div>

https://github.com/user-attachments/assets/5499cd27-3acd-48e3-ba77-b48055ae30f0


## 💬리뷰 요구사항(선택)

가게 내 리뷰 조회랑 흡사해 파일 하나로 맞춰보려 했으나 리스폰스가 살짝 달라 파일 분리했습니다.

- 자신 말고 타인까지 리뷰 조회까지 바로 가능한데 추가할까요?
- 리뷰 조회를 바텀 네비바에 넣는게 나았으려나요?
배민 카피하려고 마이페이지에 억지로 우겨넣은 느낌이 없지 않습니다.
바텀 네비바는 디자인도 해주신거라 손대기 좀 그렇네요..

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
