### PR TITLE
fix: 캐로셀 스크롤 정상화

### DIFF
--- a/src/components/feedPage/Market.style.tsx
+++ b/src/components/feedPage/Market.style.tsx
@@ -46,21 +46,13 @@ const S = {
     letter-spacing: -0.13px;
   `,
 
-  MarketWrapper: styled.TouchableOpacity`
+  MarketWrapper: styled.Pressable`
     display: flex;
     padding: 12px 0px 12px 16px;
     flex-direction: column;
     align-items: flex-start;
     gap: 10px;
     align-self: stretch;
-  `,
-
-  MarketImageContainer: styled.ScrollView`
-    display: flex;
-    flex-direction: row;
-
-    width: 100%;
-    height: 140px;
   `,
 
   MenuGradation: styled(LinearGradient)`

--- a/src/components/feedPage/Market.tsx
+++ b/src/components/feedPage/Market.tsx
@@ -15,6 +15,7 @@ const Market = ({market, onPress}: Props) => {
   );
 
   return (
+    // TODO: 터치할 때 opacity
     <S.MarketWrapper onPress={() => onPress(market.id)}>
       <FlatList
         horizontal

--- a/src/components/feedPage/Market.tsx
+++ b/src/components/feedPage/Market.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-
+import {FlatList, Pressable} from 'react-native';
 import DotIndicator from '@/assets/icons/dot.svg';
-
 import {MarketType} from '@/types/Market';
-
 import S from './Market.style';
 
 type Props = {
@@ -12,16 +10,23 @@ type Props = {
 };
 
 const Market = ({market, onPress}: Props) => {
+  const productData = market.products.filter(
+    p => p.stock && p.productStatus !== 'HIDDEN',
+  );
+
   return (
     <S.MarketWrapper onPress={() => onPress(market.id)}>
-      <S.MarketImageContainer
-        horizontal={true}
-        showsHorizontalScrollIndicator={false}>
-        {market.products
-          .filter(p => p.stock && p.productStatus !== 'HIDDEN')
-          .map(product => (
-            <S.MarketImageBox key={product.id}>
-              <S.MarketImage source={{uri: product.image}} />
+      <FlatList
+        horizontal
+        data={productData}
+        keyExtractor={item => String(item.id)}
+        showsHorizontalScrollIndicator={false}
+        // eslint-disable-next-line react-native/no-inline-styles
+        contentContainerStyle={{paddingRight: 4}}
+        renderItem={({item}) => (
+          <Pressable onPress={() => onPress(market.id)}>
+            <S.MarketImageBox>
+              <S.MarketImage source={{uri: item.image}} />
               <S.MenuGradation
                 colors={[
                   'rgba(0, 0, 0, 0.7)',
@@ -33,14 +38,15 @@ const Market = ({market, onPress}: Props) => {
                 end={{x: 0.5, y: 1}}
               />
               <S.LableWrapper>
-                <S.MenuLabel numberOfLines={1}>{product.name}</S.MenuLabel>
+                <S.MenuLabel numberOfLines={1}>{item.name}</S.MenuLabel>
                 <S.PriceLabel>
-                  {product.discountPrice.toLocaleString()}원
+                  {item.discountPrice.toLocaleString()}원
                 </S.PriceLabel>
               </S.LableWrapper>
             </S.MarketImageBox>
-          ))}
-      </S.MarketImageContainer>
+          </Pressable>
+        )}
+      />
       <S.MarketInfoDiscription>
         <S.MarketTitle>{market.name}</S.MarketTitle>
         <S.DescriptionContainer>


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

- feed page 캐로셀 스크롤 정상화

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

https://github.com/user-attachments/assets/b96d60b3-6299-48e9-a9c0-f91191c9a7bb


안드로이드도 확인했습니다!

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

기존 TouchableOpacity + map 조합에서 Pressable + FlatList로 변경했습니다.
Pressable에서 드래그를 감지하는 순간 FlatList로 터치 제어권이 넘어가 스크롤이 가능합니다.

대신 기존 TouchableOpacity에서 기본으로 유지되던 터치할 때 opacity 적용은 없어졌습니다..
적용해보려 시도해보다 배민도 터치 이벤트가 따로 없어 pr 작성합니다. TODO로 남겨놓겠습니다.
