### PR TITLE
fix: iOS back button color 주입

### DIFF
--- a/src/navigation/CartNavigator.tsx
+++ b/src/navigation/CartNavigator.tsx
@@ -11,12 +11,14 @@ import ShoppingCartScreen from '@/screens/ShoppingCartScreen';
 
 import {CartStackParamList} from '@/types/StackNavigationType';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import theme from '@/context/theme';
 
 const Stack = createStackNavigator<CartStackParamList>();
 
 const cartScreenOptions: StackNavigationOptions = {
   ...defaultOptions,
   headerTitle: () => <HeaderTitle title="장바구니" />,
+  headerTintColor: theme.colors.dark,
 };
 
 const CartNavigator = () => {

--- a/src/navigation/DetailNavigator.tsx
+++ b/src/navigation/DetailNavigator.tsx
@@ -12,8 +12,8 @@ import MarketDetailScreen from '@/screens/MarketDetailScreen';
 import OrderDetailScreen from '@/screens/OrderDetailScreen';
 import OrderDoneScreen from '@/screens/OrderDoneScreen';
 import PaymentScreen from '@/screens/PaymentScreen';
-
 import {DetailStackParamList} from '@/types/StackNavigationType';
+import theme from '@/context/theme';
 import {View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import ReviewCreateScreen from '@/screens/ReviewCreateScreen';
@@ -23,32 +23,8 @@ const Stack = createStackNavigator<DetailStackParamList>();
 
 const screenOptions: StackNavigationOptions = {
   ...defaultOptions,
+  headerTintColor: theme.colors.dark,
   headerRight: () => <CartIcon />,
-};
-
-const paymentScreenOptions: StackNavigationOptions = {
-  ...screenOptions,
-  headerTitle: () => <HeaderTitle title="예약하기" />,
-};
-
-const orderDetailScreenOptions: StackNavigationOptions = {
-  ...screenOptions,
-  headerTitle: () => <HeaderTitle title="주문내역" />,
-};
-
-const orderDoneScreenOptions: StackNavigationOptions = {
-  ...screenOptions,
-  headerTitle: () => <HeaderTitle title="주문 완료" />,
-  headerLeft: () => null,
-};
-
-const reviewCreateScreenOptions: StackNavigationOptions = {
-  ...screenOptions,
-  headerTitle: () => <HeaderTitle title="리뷰 작성" />,
-};
-const marketReviewScreenOptions: StackNavigationOptions = {
-  ...screenOptions,
-  headerTitle: () => <HeaderTitle title="리뷰" />,
 };
 
 const DetailNavigator = () => {
@@ -61,36 +37,43 @@ const DetailNavigator = () => {
       style={{flex: 1, paddingBottom: insets.bottom, backgroundColor: 'white'}}>
       <Stack.Navigator
         initialRouteName="MarketDetail"
-        screenOptions={{headerShown: true}}>
-        <Stack.Screen
-          name="MarketDetail"
-          options={screenOptions}
-          component={MarketDetailScreen}
-        />
+        screenOptions={screenOptions}>
+        <Stack.Screen name="MarketDetail" component={MarketDetailScreen} />
         <Stack.Screen
           name="Payment"
           component={PaymentScreen}
-          options={paymentScreenOptions}
+          options={{
+            headerTitle: () => <HeaderTitle title="예약하기" />,
+          }}
         />
         <Stack.Screen
           name="OrderDone"
           component={OrderDoneScreen}
-          options={orderDoneScreenOptions}
+          options={{
+            headerTitle: () => <HeaderTitle title="주문 완료" />,
+            headerLeft: () => null,
+          }}
         />
         <Stack.Screen
           name="OrderDetail"
           component={OrderDetailScreen}
-          options={orderDetailScreenOptions}
+          options={{
+            headerTitle: () => <HeaderTitle title="주문내역" />,
+          }}
         />
         <Stack.Screen
           name="ReviewCreate"
           component={ReviewCreateScreen}
-          options={reviewCreateScreenOptions}
+          options={{
+            headerTitle: () => <HeaderTitle title="리뷰 작성" />,
+          }}
         />
         <Stack.Screen
           name="MarketReview"
           component={MarketReviewScreen}
-          options={marketReviewScreenOptions}
+          options={{
+            headerTitle: () => <HeaderTitle title="리뷰" />,
+          }}
         />
       </Stack.Navigator>
     </View>

--- a/src/navigation/DetailNavigator.tsx
+++ b/src/navigation/DetailNavigator.tsx
@@ -27,6 +27,32 @@ const screenOptions: StackNavigationOptions = {
   headerRight: () => <CartIcon />,
 };
 
+const paymentScreenOptions: StackNavigationOptions = {
+  ...screenOptions,
+  headerTitle: () => <HeaderTitle title="예약하기" />,
+};
+
+const orderDoneScreenOptions: StackNavigationOptions = {
+  ...screenOptions,
+  headerTitle: () => <HeaderTitle title="주문 완료" />,
+  headerLeft: () => null,
+};
+
+const orderDetailScreenOptions: StackNavigationOptions = {
+  ...screenOptions,
+  headerTitle: () => <HeaderTitle title="주문내역" />,
+};
+
+const reviewCreateScreenOptions: StackNavigationOptions = {
+  ...screenOptions,
+  headerTitle: () => <HeaderTitle title="리뷰 작성" />,
+};
+
+const marketReviewScreenOptions: StackNavigationOptions = {
+  ...screenOptions,
+  headerTitle: () => <HeaderTitle title="리뷰" />,
+};
+
 const DetailNavigator = () => {
   const insets = useSafeAreaInsets();
 
@@ -42,38 +68,27 @@ const DetailNavigator = () => {
         <Stack.Screen
           name="Payment"
           component={PaymentScreen}
-          options={{
-            headerTitle: () => <HeaderTitle title="예약하기" />,
-          }}
+          options={paymentScreenOptions}
         />
         <Stack.Screen
           name="OrderDone"
           component={OrderDoneScreen}
-          options={{
-            headerTitle: () => <HeaderTitle title="주문 완료" />,
-            headerLeft: () => null,
-          }}
+          options={orderDoneScreenOptions}
         />
         <Stack.Screen
           name="OrderDetail"
           component={OrderDetailScreen}
-          options={{
-            headerTitle: () => <HeaderTitle title="주문내역" />,
-          }}
+          options={orderDetailScreenOptions}
         />
         <Stack.Screen
           name="ReviewCreate"
           component={ReviewCreateScreen}
-          options={{
-            headerTitle: () => <HeaderTitle title="리뷰 작성" />,
-          }}
+          options={reviewCreateScreenOptions}
         />
         <Stack.Screen
           name="MarketReview"
           component={MarketReviewScreen}
-          options={{
-            headerTitle: () => <HeaderTitle title="리뷰" />,
-          }}
+          options={marketReviewScreenOptions}
         />
       </Stack.Navigator>
     </View>

--- a/src/navigation/FeedNavigator.tsx
+++ b/src/navigation/FeedNavigator.tsx
@@ -12,6 +12,7 @@ import MapScreen from '@/screens/MapScreen';
 import FeedScreen from '@/screens/FeedScreen';
 
 import {FeedStackParamList} from '@/types/StackNavigationType';
+import theme from '@/context/theme';
 
 const Stack = createStackNavigator<FeedStackParamList>();
 
@@ -19,6 +20,7 @@ const screenOptions: StackNavigationOptions = {
   ...defaultOptions,
   headerRight: () => <CartIcon />,
   headerTitle: () => <HeaderTitle title="내 주변" />,
+  headerTintColor: theme.colors.dark,
 };
 
 const mapScreenOptions: StackNavigationOptions = {

--- a/src/navigation/HomeNavigator.tsx
+++ b/src/navigation/HomeNavigator.tsx
@@ -15,6 +15,7 @@ import SubscribeScreen from '@/screens/SubscribeScreen';
 import MyPageScreen from '@screens/MyPageScreen';
 
 import FeedNavigator from './FeedNavigator';
+import theme from '@/context/theme';
 
 import {HomeStackParamList} from '@/types/StackNavigationType';
 
@@ -24,6 +25,7 @@ const defaultScreenOptions: BottomTabNavigationOptions = {
   headerShown: true,
   headerTitleAlign: 'left' as const,
   headerRight: () => <CartIcon />,
+  headerTintColor: theme.colors.dark,
 };
 
 const myPageScreenOptions: BottomTabNavigationOptions = {

--- a/src/navigation/MyPageNavigator.tsx
+++ b/src/navigation/MyPageNavigator.tsx
@@ -13,52 +13,47 @@ import CustomerReviewScreen from '@/screens/CustomerReviewScreen';
 import NicknamePatchPage from '@/screens/MyPageScreen/NicknamePatchPage';
 
 import {MyPageStackParamList} from '@/types/StackNavigationType';
+import theme from '@/context/theme';
 
 const Stack = createStackNavigator<MyPageStackParamList>();
 
 const myPageScreenOptions: StackNavigationOptions = {
   ...defaultOptions,
-  headerTitle: () => <HeaderTitle title="마이페이지" />,
+  headerTintColor: theme.colors.dark,
 };
 
-const settingScreenOptions: StackNavigationOptions = {
-  ...defaultOptions,
-  headerTitle: () => <HeaderTitle title="설정" />,
-};
-
-const customerReviewScreenOptions: StackNavigationOptions = {
-  ...defaultOptions,
-  headerTitle: () => <HeaderTitle title="내 리뷰 조회" />,
-};
-
-const NicknameScreenOptions: StackNavigationOptions = {
-  ...defaultOptions,
-  headerTitle: () => <HeaderTitle title="닉네임 변경" />,
-};
 const MyPageNavigator = () => {
   return (
     <Stack.Navigator
       initialRouteName="MyPageRoot"
-      screenOptions={{headerShown: true}}>
+      screenOptions={myPageScreenOptions}>
       <Stack.Screen
         name="MyPage"
         component={MyPageScreen}
-        options={myPageScreenOptions}
+        options={{
+          headerTitle: () => <HeaderTitle title="마이페이지" />,
+        }}
       />
       <Stack.Screen
         name="Setting"
         component={SettingScreen}
-        options={settingScreenOptions}
+        options={{
+          headerTitle: () => <HeaderTitle title="설정" />,
+        }}
       />
       <Stack.Screen
-        name={'CustomerReview'}
+        name="CustomerReview"
         component={CustomerReviewScreen}
-        options={customerReviewScreenOptions}
+        options={{
+          headerTitle: () => <HeaderTitle title="내 리뷰 조회" />,
+        }}
       />
       <Stack.Screen
-        name={'Nickname'}
+        name="Nickname"
         component={NicknamePatchPage}
-        options={NicknameScreenOptions}
+        options={{
+          headerTitle: () => <HeaderTitle title="닉네임 변경" />,
+        }}
       />
     </Stack.Navigator>
   );

--- a/src/navigation/MyPageNavigator.tsx
+++ b/src/navigation/MyPageNavigator.tsx
@@ -22,6 +22,26 @@ const myPageScreenOptions: StackNavigationOptions = {
   headerTintColor: theme.colors.dark,
 };
 
+const myPageOptions: StackNavigationOptions = {
+  ...myPageScreenOptions,
+  headerTitle: () => <HeaderTitle title="마이페이지" />,
+};
+
+const settingOptions: StackNavigationOptions = {
+  ...myPageScreenOptions,
+  headerTitle: () => <HeaderTitle title="설정" />,
+};
+
+const customerReviewOptions: StackNavigationOptions = {
+  ...myPageScreenOptions,
+  headerTitle: () => <HeaderTitle title="내 리뷰 조회" />,
+};
+
+const nicknameOptions: StackNavigationOptions = {
+  ...myPageScreenOptions,
+  headerTitle: () => <HeaderTitle title="닉네임 변경" />,
+};
+
 const MyPageNavigator = () => {
   return (
     <Stack.Navigator
@@ -30,30 +50,22 @@ const MyPageNavigator = () => {
       <Stack.Screen
         name="MyPage"
         component={MyPageScreen}
-        options={{
-          headerTitle: () => <HeaderTitle title="마이페이지" />,
-        }}
+        options={myPageOptions}
       />
       <Stack.Screen
         name="Setting"
         component={SettingScreen}
-        options={{
-          headerTitle: () => <HeaderTitle title="설정" />,
-        }}
+        options={settingOptions}
       />
       <Stack.Screen
         name="CustomerReview"
         component={CustomerReviewScreen}
-        options={{
-          headerTitle: () => <HeaderTitle title="내 리뷰 조회" />,
-        }}
+        options={customerReviewOptions}
       />
       <Stack.Screen
         name="Nickname"
         component={NicknamePatchPage}
-        options={{
-          headerTitle: () => <HeaderTitle title="닉네임 변경" />,
-        }}
+        options={nicknameOptions}
       />
     </Stack.Navigator>
   );

--- a/src/navigation/RegisterNavigator.tsx
+++ b/src/navigation/RegisterNavigator.tsx
@@ -20,22 +20,28 @@ const registerScreenOptions: StackNavigationOptions = {
   headerTintColor: theme.colors.dark,
 };
 
+const loginScreenOptions: StackNavigationOptions = {
+  ...registerScreenOptions,
+  headerTitle: () => <HeaderTitle title="로그인" />,
+};
+
+const signupScreenOptions: StackNavigationOptions = {
+  ...registerScreenOptions,
+  headerTitle: () => <HeaderTitle title="회원가입" />,
+};
+
 const RegisterNavigator = () => {
   return (
     <Stack.Navigator screenOptions={registerScreenOptions}>
       <Stack.Screen
         name="Login"
         component={LoginScreen}
-        options={{
-          headerTitle: () => <HeaderTitle title="로그인" />,
-        }}
+        options={loginScreenOptions}
       />
       <Stack.Screen
         name="SignUp"
         component={SignupScreen}
-        options={{
-          headerTitle: () => <HeaderTitle title="회원가입" />,
-        }}
+        options={signupScreenOptions}
       />
     </Stack.Navigator>
   );

--- a/src/navigation/RegisterNavigator.tsx
+++ b/src/navigation/RegisterNavigator.tsx
@@ -11,31 +11,31 @@ import LoginScreen from '@screens/RegisterScreen/LoginScreen';
 import SignupScreen from '@screens/RegisterScreen/SignupScreen';
 
 import {RegisterStackParamList} from '@/types/StackNavigationType';
+import theme from '@/context/theme';
 
 const Stack = createStackNavigator<RegisterStackParamList>();
 
-const loginScreenOptions: StackNavigationOptions = {
+const registerScreenOptions: StackNavigationOptions = {
   ...defaultOptions,
-  headerTitle: () => <HeaderTitle title="로그인" />,
-};
-
-const signupScreenOptions: StackNavigationOptions = {
-  ...defaultOptions,
-  headerTitle: () => <HeaderTitle title="회원가입" />,
+  headerTintColor: theme.colors.dark,
 };
 
 const RegisterNavigator = () => {
   return (
-    <Stack.Navigator screenOptions={{headerShown: true}}>
+    <Stack.Navigator screenOptions={registerScreenOptions}>
       <Stack.Screen
         name="Login"
         component={LoginScreen}
-        options={loginScreenOptions}
+        options={{
+          headerTitle: () => <HeaderTitle title="로그인" />,
+        }}
       />
       <Stack.Screen
         name="SignUp"
         component={SignupScreen}
-        options={signupScreenOptions}
+        options={{
+          headerTitle: () => <HeaderTitle title="회원가입" />,
+        }}
       />
     </Stack.Navigator>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

- iOS 백버튼 color 주입

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

<p >
  <img src="https://github.com/user-attachments/assets/54ae243b-0796-4014-9fc9-ad0d6dca3ec7" width="360" />
</p>


## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

navigatorOption을 상단에 선언하는게 나을까요?
commonScreenOption 선언 이후 페이지에서 덮어쓰는 형식으로 변경해봤습니다.
기존 방식이 나으면 원복하겠습니다~!


lint warning이 발생했었네요.. 이전에도 그래서 지금 형식으로 변경했던 것 같습니다.
common을 선언하고, 상단에서 option을 선언 이후 각 페이지에 주입했습니다.
어프루브 눌러주시면 어드민도 진행할게요!

rn 뭔가 감싸진게 많네요 속성을 잘 넣어주면 잘되네요
