### PR TITLE
fix: 가게 상세 페이지 메뉴가 적을 때 SideTagView height 늘어나는 현상 수정

### DIFF
--- a/src/screens/MarketDetailScreen/MarketDetail.style.tsx
+++ b/src/screens/MarketDetailScreen/MarketDetail.style.tsx
@@ -75,7 +75,7 @@ const S = {
 
   SideTagBarScrollView: styled.ScrollView`
     padding: 8px 0;
-    height: 104px;
+    flex-grow: 0;
   `,
 
   SideBarView: styled.View<{selected: boolean}>`
@@ -88,7 +88,7 @@ const S = {
       selected ? theme.colors.primary : 'white'};
     border: ${({selected, theme}) =>
       selected ? '' : `1px solid ${theme.colors.primary}`};
-    margin: 5px;
+    margin: 4px;
     border-radius: 10px;
   `,
   SideBarText: styled.Text<{selected: boolean}>`
@@ -101,6 +101,10 @@ const S = {
     width: 390px;
     height: 8px;
     background: #ecf3f1;
+  `,
+
+  MenuWrapper: styled.View`
+    flex: 1;
   `,
 
   MenuScrollView: styled.ScrollView``,

--- a/src/screens/MarketDetailScreen/MarketDetailPage.tsx
+++ b/src/screens/MarketDetailScreen/MarketDetailPage.tsx
@@ -6,6 +6,7 @@ import {
   NativeSyntheticEvent,
   ScrollView,
   TouchableOpacity,
+  View,
 } from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
@@ -419,30 +420,33 @@ const MarketDetailPage = ({
         ))}
       </S.SideTagBarScrollView>
 
-      <S.MenuScrollView
-        ref={scrollViewRef}
-        onScroll={handleScroll}
-        showsVerticalScrollIndicator={false}
-        onLayout={updateSectionOffsets}
-        decelerationRate="fast">
-        {Object.entries(sortedProductsByTags).map(([tag, productsByTag]) => (
-          <S.MenuView key={tag} onLayout={handleLayout(tag)}>
-            <S.TagWrapper>
-              <S.MenuText>{tag}</S.MenuText>
-            </S.TagWrapper>
-            {productsByTag.map(product => (
-              <Menu
-                key={product.id}
-                product={product}
-                initCount={
-                  cart.find(item => item.productId === product.id)?.count || 0
-                }
-                onCountChange={handleCountChange}
-              />
-            ))}
-          </S.MenuView>
-        ))}
-      </S.MenuScrollView>
+      <S.MenuWrapper>
+        <S.MenuScrollView
+          ref={scrollViewRef}
+          onScroll={handleScroll}
+          showsVerticalScrollIndicator={false}
+          onLayout={updateSectionOffsets}
+          contentContainerStyle={{flexGrow: 1}}
+          decelerationRate="fast">
+          {Object.entries(sortedProductsByTags).map(([tag, productsByTag]) => (
+            <S.MenuView key={tag} onLayout={handleLayout(tag)}>
+              <S.TagWrapper>
+                <S.MenuText>{tag}</S.MenuText>
+              </S.TagWrapper>
+              {productsByTag.map(product => (
+                <Menu
+                  key={product.id}
+                  product={product}
+                  initCount={
+                    cart.find(item => item.productId === product.id)?.count || 0
+                  }
+                  onCountChange={handleCountChange}
+                />
+              ))}
+            </S.MenuView>
+          ))}
+        </S.MenuScrollView>
+      </S.MenuWrapper>
 
       <BottomButton
         disabled={isMarketClosed}

--- a/src/screens/MarketDetailScreen/MarketDetailPage.tsx
+++ b/src/screens/MarketDetailScreen/MarketDetailPage.tsx
@@ -6,7 +6,6 @@ import {
   NativeSyntheticEvent,
   ScrollView,
   TouchableOpacity,
-  View,
 } from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
@@ -426,7 +425,6 @@ const MarketDetailPage = ({
           onScroll={handleScroll}
           showsVerticalScrollIndicator={false}
           onLayout={updateSectionOffsets}
-          contentContainerStyle={{flexGrow: 1}}
           decelerationRate="fast">
           {Object.entries(sortedProductsByTags).map(([tag, productsByTag]) => (
             <S.MenuView key={tag} onLayout={handleLayout(tag)}>


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

가게 상세 페이지 메뉴가 적을때 태그 바가 늘어나는 현상 bug fix

### 스크린샷 (선택)

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
<img width="360" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-17 at 16 28 53" src="https://github.com/user-attachments/assets/10e27cbc-21b5-4514-9633-3130e6a8d61f" />


<img width="360" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-17 at 16 28 45" src="https://github.com/user-attachments/assets/f4693fd5-c864-4f10-8446-a8e6b8255971" />

<img width="360" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-17 at 16 29 02" src="https://github.com/user-attachments/assets/2256268b-8547-437e-80a6-8f2e3090edb9" />

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

flex-grow: 0을 이용해 늘어나는 현상을 방지하고, 
MarketInfoView 하단을 View로 감싸 항상 flex: 1로 늘어나게 하여 방지했습니다.

RN ScrollView 사용시 height 적용이 까다로워 부모 View로 감싸는 방식이 통용되는 것 같습니다.
<img width="1666" height="542" alt="image" src="https://github.com/user-attachments/assets/263d565d-1922-4208-a3af-68a3ef4cbfba" />

