### PR TITLE
fix: api pending 스크린 반영을 통한 ux 개선 및 중복 전송 방지

### DIFF
--- a/src/components/LoginPage/CredentialLogin.tsx
+++ b/src/components/LoginPage/CredentialLogin.tsx
@@ -20,7 +20,7 @@ const CredentialLogin = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
-  const {login} = useProfile();
+  const {login, loading} = useProfile();
 
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
 
@@ -31,7 +31,7 @@ const CredentialLogin = () => {
       <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
         <S.LoginFormWrapper>
           <TextInput
-            placeholder={'아이디'}
+            placeholder={'이메일'}
             value={email}
             onChange={e => setEmail(e.nativeEvent.text)}
           />
@@ -43,7 +43,7 @@ const CredentialLogin = () => {
           />
           <S.SubmitButton
             mode="contained"
-            disabled={!email || !password}
+            disabled={!email || !password || loading}
             onPress={async () => {
               login(
                 {email, password},

--- a/src/components/common/ActivityIndicator.style.tsx
+++ b/src/components/common/ActivityIndicator.style.tsx
@@ -1,7 +1,5 @@
 import styled from '@emotion/native';
 
-const Container = styled.View``;
-
 const S = {
   Container: styled.View`
     position: absolute;

--- a/src/components/common/ActivityIndicator.style.tsx
+++ b/src/components/common/ActivityIndicator.style.tsx
@@ -1,13 +1,19 @@
 import styled from '@emotion/native';
 
-const Container = styled.View`
-  display: flex;
-  margin-top: 64px;
-  align-items: center;
-`;
+const Container = styled.View``;
 
 const S = {
-  Container,
+  Container: styled.View`
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(255, 255, 255, 0.7);
+    z-index: 1000;
+  `,
 };
 
 export default S;

--- a/src/screens/MarketDetailScreen/MarketDetailPage.tsx
+++ b/src/screens/MarketDetailScreen/MarketDetailPage.tsx
@@ -55,8 +55,12 @@ const MarketDetailPage = ({
   const [selectedTag, setSelectedTag] = useState<string>('');
   const scrollViewRef = useRef<ScrollView>(null);
   const tagScrollViewRef = useRef<ScrollView>(null);
-  const [sectionOffsets, setSectionOffsets] = useState<{[key: string]: number}>({});
-  const [sectionHeights, setSectionHeights] = useState<{[key: string]: number}>({});
+  const [sectionOffsets, setSectionOffsets] = useState<{[key: string]: number}>(
+    {},
+  );
+  const [sectionHeights, setSectionHeights] = useState<{[key: string]: number}>(
+    {},
+  );
   const [tagWidths, setTagWidths] = useState<{[key: string]: number}>({});
   const [marketIsLiked, setMarketIsLiked] = useState<boolean>(hasLike);
   const [modalVisible, setModalVisible] = useState(false);
@@ -75,12 +79,18 @@ const MarketDetailPage = ({
     );
   };
 
-  const handleCart = (productId: number, productName: string, count: number) => {
+  const handleCart = (
+    productId: number,
+    productName: string,
+    count: number,
+  ) => {
     setCart(prevCart => {
       if (count === 0) {
         return prevCart.filter(item => item.productId !== productId);
       }
-      const existingItemIndex = prevCart.findIndex(item => item.productId === productId);
+      const existingItemIndex = prevCart.findIndex(
+        item => item.productId === productId,
+      );
       if (existingItemIndex !== -1) {
         const updatedCart = [...prevCart];
         updatedCart[existingItemIndex] = {productId, productName, count};
@@ -91,20 +101,23 @@ const MarketDetailPage = ({
     });
   };
 
-  const productsByTags = products.reduce((acc: {[key: string]: ProductType[]}, product) => {
-    if (product.tags.length === 0) {
-      if (!acc['메뉴']) acc['메뉴'] = [];
-      acc['메뉴'].push(product);
-      return acc;
-    }
+  const productsByTags = products.reduce(
+    (acc: {[key: string]: ProductType[]}, product) => {
+      if (product.tags.length === 0) {
+        if (!acc['메뉴']) acc['메뉴'] = [];
+        acc['메뉴'].push(product);
+        return acc;
+      }
 
-    product.tags.forEach(tagObj => {
-      const tag = tagObj.tagName;
-      if (!acc[tag]) acc[tag] = [];
-      acc[tag].push(product);
-    });
-    return acc;
-  }, {});
+      product.tags.forEach(tagObj => {
+        const tag = tagObj.tagName;
+        if (!acc[tag]) acc[tag] = [];
+        acc[tag].push(product);
+      });
+      return acc;
+    },
+    {},
+  );
 
   const sortedProductsByTags = Object.entries(productsByTags)
     .sort(([tagA, productsA], [tagB, productsB]) => {
@@ -120,7 +133,11 @@ const MarketDetailPage = ({
   const scrollToSection = useCallback(
     (tag: string) => {
       if (scrollViewRef.current && sectionOffsets[tag] !== undefined) {
-        scrollViewRef.current.scrollTo({x: 0, y: sectionOffsets[tag] + 1, animated: true});
+        scrollViewRef.current.scrollTo({
+          x: 0,
+          y: sectionOffsets[tag] + 1,
+          animated: true,
+        });
       }
     },
     [sectionOffsets],
@@ -150,12 +167,18 @@ const MarketDetailPage = ({
       const sectionHeight = sectionHeights[tag] || 0;
       const sectionOffset = sectionOffsets[tag];
       const sectionEndOffset = sectionOffset + sectionHeight;
-      if (contentOffsetY >= sectionOffset && contentOffsetY < sectionEndOffset) {
+      if (
+        contentOffsetY >= sectionOffset &&
+        contentOffsetY < sectionEndOffset
+      ) {
         newSelectedTag = tag;
       }
     });
 
-    if (newSelectedTag !== lastTag && contentOffsetY >= sectionOffsets[lastTag]) {
+    if (
+      newSelectedTag !== lastTag &&
+      contentOffsetY >= sectionOffsets[lastTag]
+    ) {
       newSelectedTag = lastTag;
     }
 
@@ -228,7 +251,10 @@ const MarketDetailPage = ({
     }
   };
 
-  const addProductToBucket = async (marketId: number, addProducts: CartItem[]) => {
+  const addProductToBucket = async (
+    marketId: number,
+    addProducts: CartItem[],
+  ) => {
     if (addProducts.length === 0) {
       Alert.alert('장바구니가 비어있습니다.');
       return;
@@ -305,7 +331,9 @@ const MarketDetailPage = ({
             <S.MarketDescription>{summary}</S.MarketDescription>
           </S.MarketMainInfoWrapper>
           <S.MarketSideInfoWrapper>
-            <S.MarketTimeDescription>{remainingPickupTime}</S.MarketTimeDescription>
+            <S.MarketTimeDescription>
+              {remainingPickupTime}
+            </S.MarketTimeDescription>
             <S.MarketPickupTimeWrapper>
               <S.MarketPickupTimeRow>
                 <S.MarketSideInfo>영업 시간: </S.MarketSideInfo>
@@ -315,17 +343,25 @@ const MarketDetailPage = ({
                 </TouchableOpacity>
               </S.MarketPickupTimeRow>
             </S.MarketPickupTimeWrapper>
-            <S.MarketSideInfo>{address} {specificAddress}</S.MarketSideInfo>
+            <S.MarketSideInfo>
+              {address} {specificAddress}
+            </S.MarketSideInfo>
           </S.MarketSideInfoWrapper>
           <S.MarketBottomInfo>
             <S.ReviewInfoWrapper>
               {reviewNum !== 0 && averageRating && (
                 <>
                   <StarIcon name="star" color="#FFD700" size={24} />
-                  <S.ReviewScoreText>{averageRating.toFixed(1)}</S.ReviewScoreText>
+                  <S.ReviewScoreText>
+                    {averageRating.toFixed(1)}
+                  </S.ReviewScoreText>
                   <S.ReviewTouchableOpacity onPress={navigateReviewScreen}>
                     <S.ReviewCountText>리뷰 {reviewNum}개</S.ReviewCountText>
-                    <ChevronIcon name="chevron-right" size={36} color="#495057" />
+                    <ChevronIcon
+                      name="chevron-right"
+                      size={36}
+                      color="#495057"
+                    />
                   </S.ReviewTouchableOpacity>
                 </>
               )}
@@ -348,7 +384,9 @@ const MarketDetailPage = ({
               onLayout={handleTagLayout(tag)}
               onPress={() => handleTagPress(tag)}>
               <S.SideBarView selected={selectedTag === tag}>
-                <S.SideBarText selected={selectedTag === tag}>{tag}</S.SideBarText>
+                <S.SideBarText selected={selectedTag === tag}>
+                  {tag}
+                </S.SideBarText>
               </S.SideBarView>
             </TouchableOpacity>
           ))}
@@ -361,21 +399,26 @@ const MarketDetailPage = ({
             showsVerticalScrollIndicator={false}
             onLayout={updateSectionOffsets}
             decelerationRate="fast">
-            {Object.entries(sortedProductsByTags).map(([tag, productsByTag]) => (
-              <S.MenuView key={tag} onLayout={handleLayout(tag)}>
-                <S.TagWrapper>
-                  <S.MenuText>{tag}</S.MenuText>
-                </S.TagWrapper>
-                {productsByTag.map(product => (
-                  <Menu
-                    key={product.id}
-                    product={product}
-                    initCount={cart.find(item => item.productId === product.id)?.count || 0}
-                    onCountChange={handleCountChange}
-                  />
-                ))}
-              </S.MenuView>
-            ))}
+            {Object.entries(sortedProductsByTags).map(
+              ([tag, productsByTag]) => (
+                <S.MenuView key={tag} onLayout={handleLayout(tag)}>
+                  <S.TagWrapper>
+                    <S.MenuText>{tag}</S.MenuText>
+                  </S.TagWrapper>
+                  {productsByTag.map(product => (
+                    <Menu
+                      key={product.id}
+                      product={product}
+                      initCount={
+                        cart.find(item => item.productId === product.id)
+                          ?.count || 0
+                      }
+                      onCountChange={handleCountChange}
+                    />
+                  ))}
+                </S.MenuView>
+              ),
+            )}
           </S.MenuScrollView>
         </S.MenuWrapper>
 

--- a/src/screens/MarketDetailScreen/MarketDetailPage.tsx
+++ b/src/screens/MarketDetailScreen/MarketDetailPage.tsx
@@ -23,6 +23,8 @@ import {RootStackParamList} from '@/types/StackNavigationType';
 import {BucketProductType} from '@/types/Bucket';
 import {ProductType} from '@ummgoban/shared/lib';
 
+import CustomActivityIndicator from '@/components/common/ActivityIndicator';
+
 import {zeroPad} from '@utils/date';
 
 import S from './MarketDetail.style';
@@ -60,6 +62,9 @@ const MarketDetailPage = ({
   const [sectionHeights, setSectionHeights] = useState<{[key: string]: number}>(
     {},
   );
+
+  const [isCartPending, setIsCartPending] = useState(false);
+
   const [tagWidths, setTagWidths] = useState<{[key: string]: number}>({});
   const [marketIsLiked, setMarketIsLiked] = useState<boolean>(hasLike);
   const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -241,6 +246,7 @@ const MarketDetailPage = ({
 
   const handleCheckout = async (marketId: number, cartItems: CartItem[]) => {
     try {
+      setIsCartPending(true);
       const bucketProducts: BucketProductType[] = cartItems.map(cartItem => {
         const productDetails = products.find(
           (product): product is ProductType =>
@@ -277,6 +283,8 @@ const MarketDetailPage = ({
       }
     } catch (error) {
       console.error('Error in handleCheckout:', error);
+    } finally {
+      setIsCartPending(false);
     }
   };
   const addProductToBucket = async (
@@ -447,7 +455,7 @@ const MarketDetailPage = ({
       </S.MenuWrapper>
 
       <BottomButton
-        disabled={isMarketClosed}
+        disabled={isMarketClosed || isCartPending}
         onPress={() => {
           if (profile) {
             addProductToBucket(id, cart);
@@ -458,9 +466,12 @@ const MarketDetailPage = ({
         {isMarketClosed
           ? '영업이 종료되었어요.'
           : profile
-            ? `예약하기 (${cart.length})`
+            ? isCartPending
+              ? '잠시 기다려주세요.'
+              : `예약하기 (${cart.length})`
             : `로그인하고 장바구니에 담기`}
       </BottomButton>
+      {isCartPending && <CustomActivityIndicator />}
     </S.MarketDetailInfoView>
   );
 };

--- a/src/screens/MyPageScreen/NicknamePatchPage.tsx
+++ b/src/screens/MyPageScreen/NicknamePatchPage.tsx
@@ -20,7 +20,7 @@ const NicknamePatchPage = ({navigation}: NicknamePatchScreenProps) => {
   const {profile} = useProfile();
   const queryClient = useQueryClient();
   const [inputNickname, setInputNickname] = useState<string>('');
-  const {mutate: nicknamePatchMutate} = usePatchNicknameMutation();
+  const {mutate: nicknamePatchMutate, isPending} = usePatchNicknameMutation();
 
   const handleNicknamePatchMutate = (nickname: string) => {
     nicknamePatchMutate(nickname, {
@@ -45,7 +45,7 @@ const NicknamePatchPage = ({navigation}: NicknamePatchScreenProps) => {
         onChange={e => setInputNickname(e.nativeEvent.text)}
       />
       <BottomButton
-        disabled={!inputNickname}
+        disabled={!inputNickname || isPending}
         onPress={() => {
           handleNicknamePatchMutate(inputNickname);
         }}>

--- a/src/screens/MyPageScreen/UserMyPage.tsx
+++ b/src/screens/MyPageScreen/UserMyPage.tsx
@@ -6,7 +6,7 @@ import {Alert, Linking, RefreshControl} from 'react-native';
 import ListBox from '@/components/common/ListBox';
 import NavigationTextButton from '@/components/common/NavigateTextButton';
 import {Profile} from '@components/myPage';
-
+import CustomActivityIndicator from '@/components/common/ActivityIndicator';
 import useProfile from '@/hooks/useProfile';
 
 import {RootStackParamList} from '@/types/StackNavigationType';
@@ -31,8 +31,10 @@ const UserMyPage = ({profile, refreshing, onRefresh}: UserMyPageProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const {logout, withdraw} = useProfile();
+  const [isPending, setIsPending] = useState(false);
 
   const logoutCallback = useCallback(() => {
+    setIsPending(false);
     Alert.alert('로그아웃 되었습니다.', '', [
       {
         onPress: () =>
@@ -49,6 +51,7 @@ const UserMyPage = ({profile, refreshing, onRefresh}: UserMyPageProps) => {
       refreshControl={
         <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
       }>
+      {isPending && <CustomActivityIndicator />}
       <S.ProfileImageSection>
         <Profile image={profile.image} />
       </S.ProfileImageSection>
@@ -114,6 +117,8 @@ const UserMyPage = ({profile, refreshing, onRefresh}: UserMyPageProps) => {
               fontColor="#888"
               isNotice={false}
               onPress={() => {
+                if (isPending) return;
+                setIsPending(true);
                 logout({
                   onSuccess: logoutCallback,
                   onError: logoutCallback,
@@ -159,9 +164,12 @@ const UserMyPage = ({profile, refreshing, onRefresh}: UserMyPageProps) => {
                       {
                         text: '탈퇴하기',
                         onPress: () => {
+                          if (isPending) return;
+                          setIsPending(true);
                           setIsOpen(false);
                           withdraw({
                             onSuccess: () => {
+                              setIsPending(false);
                               navigation.navigate('Home', {
                                 screen: 'Feed',
                               });
@@ -173,6 +181,7 @@ const UserMyPage = ({profile, refreshing, onRefresh}: UserMyPageProps) => {
                               ]);
                             },
                             onError: error => {
+                              setIsPending(false);
                               Alert.alert(
                                 '탈퇴 중에 오류가 발생해요.',
                                 error.errorMessage,

--- a/src/screens/PaymentScreen/PaymentPage.tsx
+++ b/src/screens/PaymentScreen/PaymentPage.tsx
@@ -29,6 +29,7 @@ import {format} from '@/utils/date';
 import S from './PaymentPage.style';
 import {Button, Text} from 'react-native-paper';
 import {useQueryClient} from '@tanstack/react-query';
+import CustomActivityIndicator from '@/components/common/ActivityIndicator';
 
 const nowDate = format(new Date(), 'YYYY-MM-DD');
 
@@ -65,6 +66,7 @@ const PaymentPage = ({cart, marketId}: Props) => {
   const queryClient = useQueryClient();
   const {mutateAsync: requestOrder} = useRequestOrderMutation();
 
+  const [isOrderPending, setIsOrderPending] = useState(false);
   const {originPrice, discountPrice} = useMemo(
     () =>
       cart.products.reduce(
@@ -90,8 +92,12 @@ const PaymentPage = ({cart, marketId}: Props) => {
     );
   }
 
+  // if (isOrderPending) {
+  //   return <CustomActivityIndicator />;
+  // }
   return (
     <S.PaymentPage>
+      {isOrderPending && <CustomActivityIndicator />}
       <S.ScrollView>
         <DatePickerCard
           pickupReservedAt={pickupReservedAt}
@@ -135,7 +141,11 @@ const PaymentPage = ({cart, marketId}: Props) => {
         />
       </S.ScrollView>
       <BottomButton
+        disabled={isOrderPending}
         onPress={async () => {
+          if (isOrderPending) return;
+          setIsOrderPending(true);
+
           // if (paymentWidgetControl == null || agreementWidgetControl == null) {
           //   Alert.alert('주문 정보가 초기화되지 않았습니다.');
           //   return;
@@ -198,7 +208,9 @@ const PaymentPage = ({cart, marketId}: Props) => {
           // }
         }}>
         {/* TODO: 결제하기로 변경 */}
-        {`${discountPrice.toLocaleString()}원 예약하기`}
+        {isOrderPending
+          ? '예약 중..'
+          : `${discountPrice.toLocaleString()}원 예약하기`}
       </BottomButton>
     </S.PaymentPage>
   );

--- a/src/screens/RegisterScreen/LoginScreen.tsx
+++ b/src/screens/RegisterScreen/LoginScreen.tsx
@@ -14,14 +14,16 @@ import CredentialLogin from '@/components/LoginPage/CredentialLogin';
 import useProfile from '@/hooks/useProfile';
 
 import S from './LoginScreen.style';
+import CustomActivityIndicator from '@/components/common/ActivityIndicator';
 
 const LoginScreen = () => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
-  const {loginWithOAuth} = useProfile();
+  const {loginWithOAuth, loading} = useProfile();
 
   return (
     <S.Container behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+      {loading && <CustomActivityIndicator />}
       <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
         <S.LoginPageContainer>
           <S.MomChanPickLogoWrapper>

--- a/src/screens/ReviewCreateScreen/index.tsx
+++ b/src/screens/ReviewCreateScreen/index.tsx
@@ -17,7 +17,7 @@ import {
   TouchableWithoutFeedback,
   Platform,
 } from 'react-native';
-import {ActivityIndicator} from 'react-native-paper';
+import CustomActivityIndicator from '@/components/common/ActivityIndicator';
 
 type ReviewCreateScreenProps = StackScreenProps<
   DetailStackParamList,
@@ -29,7 +29,7 @@ const ReviewCreateScreen = ({navigation, route}: ReviewCreateScreenProps) => {
   const [rating, setRating] = useState<number>(5);
   const [review, setReview] = useState<string>('');
   const [reviewImageUris, setReviewImageUris] = useState<string[]>([]);
-  const [isReviewUploading, setIsReveiwUploding] = useState<boolean>(false);
+  const [isReviewUploading, setisReviewUploading] = useState<boolean>(false);
 
   const {mutateAsync: reviewImageUploadMutate} = useUploadReviewImageMutation();
   const {mutate: reviewCreateMutate} = useCreateReviewMutation(orderId);
@@ -46,7 +46,7 @@ const ReviewCreateScreen = ({navigation, route}: ReviewCreateScreenProps) => {
 
   const handleReviewCreateMutate = async () => {
     try {
-      setIsReveiwUploding(true);
+      setisReviewUploading(true);
 
       const uploadedUrls: string[] = [];
 
@@ -78,21 +78,20 @@ const ReviewCreateScreen = ({navigation, route}: ReviewCreateScreenProps) => {
             navigation.navigate('Home', {screen: 'Feed'});
           },
           onError: () => {
-            // FIXME: 에러 핸들링
             Alert.alert('리뷰 작성에 실패했어요. 다시 시도해주세요!');
-          },
-          onSettled: () => {
-            setIsReveiwUploding(false);
           },
         },
       );
     } catch (e) {
       console.error('리뷰 작성 실패:', e);
       Alert.alert('리뷰 작성 중 오류가 발생했습니다.');
+    } finally {
+      setisReviewUploading(false);
     }
   };
   return (
     <S.Container behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+      {isReviewUploading && <CustomActivityIndicator />}
       <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
         <>
           <S.ReviewCreateScreenContainer>
@@ -128,16 +127,11 @@ const ReviewCreateScreen = ({navigation, route}: ReviewCreateScreenProps) => {
               />
             </S.ReviewInputContainer>
             <BottomButton
-              disabled={!review || review.length === 0}
+              disabled={!review || review.length === 0 || isReviewUploading}
               onPress={handleReviewCreateMutate}>
               리뷰 작성하기
             </BottomButton>
           </S.ReviewCreateScreenContainer>
-          {isReviewUploading && (
-            <S.LoadingOverlay>
-              <ActivityIndicator size="small" animating />
-            </S.LoadingOverlay>
-          )}
         </>
       </TouchableWithoutFeedback>
     </S.Container>


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #225 

## 📝작업 내용

- api pending 시 스크린에 반영
  -   중복 전송의 side-effect가 큰 api와 및 상태 변경 api 위주로 진행
- 사장님 요구사항 중 credential 로그인 id placeholder 아이디 -> 이메일로 변경

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)


https://github.com/user-attachments/assets/2e6cf71e-7e91-4c16-ad12-1699d3236f92

https://github.com/user-attachments/assets/6b394dc2-68f6-4ce1-bd85-e051e0c78e76

https://github.com/user-attachments/assets/47412e88-da97-41d7-b2cf-7bf5e35f47c3



## 💬리뷰 요구사항(선택)

기존 CustomActivityIndicator를 오버레이 형식으로 변경하여 적용했습니다.

커밋 메시지 별 스크린에 동일 로직 적용했습니다.
MutateAsync로 useMutation 사용하고 있는 스크린은 부득이하게 useState로 상태 하나 더 관리하여
async 함수 내부에서 상태 관리하였습니다.


<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
