### PR TITLE
refactor: image-picker 모듈 분리

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,8 +90,8 @@ android {
         applicationId "com.ummgoban.momchanpick"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 32 // TODO: update version code
-        versionName "1.1.2.3" // TODO: update version name
+        versionCode 33 // TODO: update version code
+        versionName "1.1.2.4" // TODO: update version name
         resValue "string", "NAVER_MAP_CLIENT_ID", project.env.get("NAVER_MAP_CLIENT_ID") ?: ""
         resValue "string", "build_config_package", "com.ummgoban.momchanpick"
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-xmlns:tools="http://schemas.android.com/tools" package="com.ummgoban.momchanpick">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="com.ummgoban.momchanpick">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -10,8 +9,10 @@ xmlns:tools="http://schemas.android.com/tools" package="com.ummgoban.momchanpick
 
   <!-- 이미지/카메라 -->
   <uses-permission android:name="android.permission.CAMERA"/>
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <!-- <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" /> -->
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
+  <uses-feature android:name="android.hardware.camera" android:required="false"/>
   
     <application
       android:name=".MainApplication"
@@ -27,8 +28,8 @@ xmlns:tools="http://schemas.android.com/tools" package="com.ummgoban.momchanpick
       android:usesCleartextTraffic="true">
 
     <meta-data
-            android:name="com.naver.maps.map.CLIENT_ID"
-           android:value="@string/NAVER_MAP_CLIENT_ID" />
+        android:name="com.naver.maps.map.CLIENT_ID"
+        android:value="@string/NAVER_MAP_CLIENT_ID" />
            
     <meta-data
         android:name="com.google.firebase.messaging.default_notification_channel_id"
@@ -58,16 +59,16 @@ xmlns:tools="http://schemas.android.com/tools" package="com.ummgoban.momchanpick
         <!-- Redirect URI: "kakao{NATIVE_APP_KEY}://oauth“ -->
         <!-- TODO: kakao앱키 kakao~-->
         <data android:host="oauth"
-            android:scheme="@string/KAKAO_NATIVE_KEY" />
+              android:scheme="@string/KAKAO_NATIVE_KEY" />
       </intent-filter>
     </activity>
   
-    <service android:name="com.google.android.gms.metadata.ModuleDependencies" android:enabled="false" android:exported="false">
+    <!-- <service android:name="com.google.android.gms.metadata.ModuleDependencies" android:enabled="false" android:exported="false">
       <intent-filter>
         <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
       </intent-filter>
       <meta-data android:name="photopicker_activity:0:required" android:value="" />
-    </service>
+    </service> -->
 
     </application>
 </manifest>

--- a/src/modules/imagePicker/hook/use-image-picker.reducer.ts
+++ b/src/modules/imagePicker/hook/use-image-picker.reducer.ts
@@ -1,0 +1,58 @@
+import {ImagePickerError} from '../lib/image-picker.error';
+
+type ImagePickerState = {
+  latestPath: string | null;
+  loading?: boolean;
+  error?: ImagePickerError | null;
+};
+
+type ImagePickerActionPayload = {
+  path: string | null;
+  loading?: boolean;
+  error?: ImagePickerError | null;
+};
+
+type ImagePickerActionType =
+  | 'SET_IMAGE_PATH'
+  | 'SET_LOADING'
+  | 'DONE_WITH_ERROR'
+  | 'DONE';
+
+type ImagePickerAction = {
+  type: ImagePickerActionType;
+  payload: Partial<ImagePickerActionPayload>;
+};
+
+export const imagePickerReducer = (
+  state: ImagePickerState,
+  action: ImagePickerAction,
+): ImagePickerState => {
+  switch (action.type) {
+    case 'SET_IMAGE_PATH':
+      return {
+        ...state,
+        latestPath: action.payload.path ?? null,
+        loading: action.payload.loading,
+        error: action.payload.error,
+      };
+    case 'SET_LOADING':
+      return {
+        ...state,
+        loading: action.payload.loading ?? false,
+      };
+    case 'DONE':
+      return {
+        ...state,
+        loading: false,
+        error: null,
+      };
+    case 'DONE_WITH_ERROR':
+      return {
+        ...state,
+        loading: false,
+        error: action.payload.error ?? null,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/modules/imagePicker/hook/use-image-picker.ts
+++ b/src/modules/imagePicker/hook/use-image-picker.ts
@@ -45,7 +45,7 @@ export const useImagePicker = () => {
             error instanceof ImagePickerError
               ? error
               : new ImagePickerError(
-                  error as string,
+                  error?.toString?.() ?? 'Unknown error',
                   ImagePickerErrorCode.E_UNKNOWN,
                 ),
         },

--- a/src/modules/imagePicker/hook/use-image-picker.ts
+++ b/src/modules/imagePicker/hook/use-image-picker.ts
@@ -1,0 +1,83 @@
+import {useReducer} from 'react';
+import {Alert} from 'react-native';
+
+import * as imagePickerLib from '../lib/image-picker';
+import {
+  ImagePickerError,
+  ImagePickerErrorCode,
+} from '../lib/image-picker.error';
+
+import {imagePickerReducer} from './use-image-picker.reducer';
+
+export const useImagePicker = () => {
+  const [state, dispatch] = useReducer(imagePickerReducer, {
+    latestPath: null,
+    loading: false,
+    error: null,
+  });
+
+  async function handleImageAction(
+    action: () => Promise<string>,
+  ): Promise<string | null> {
+    try {
+      dispatch({type: 'SET_LOADING', payload: {loading: true}});
+      const imagePath = await action();
+      dispatch({
+        type: 'SET_IMAGE_PATH',
+        payload: {path: imagePath, loading: false, error: null},
+      });
+      return imagePath;
+    } catch (error) {
+      if (
+        error instanceof ImagePickerError &&
+        error.code === ImagePickerErrorCode.E_PICKER_CANCELLED
+      ) {
+        // 사용자가 이미지 피커를 취소했을 경우 에러를 던지지 않는다.
+        dispatch({type: 'DONE', payload: {}});
+        console.info('사용자가 이미지 피커를 취소했습니다.');
+        return null;
+      }
+
+      dispatch({
+        type: 'DONE_WITH_ERROR',
+        payload: {
+          error:
+            error instanceof ImagePickerError
+              ? error
+              : new ImagePickerError(
+                  error as string,
+                  ImagePickerErrorCode.E_UNKNOWN,
+                ),
+        },
+      });
+
+      console.error(error);
+      Alert.alert('이미지 업로드에 실패했습니다.');
+    }
+    return null;
+  }
+
+  /**
+   *
+   * @returns 선택된 이미지의 경로. null이면 사용자가 이미지 피커를 취소
+   */
+  async function pickImage(): Promise<string | null> {
+    return handleImageAction(imagePickerLib.pickImage);
+  }
+
+  /**
+   *
+   * @returns 선택된 이미지의 경로. null이면 사용자가 이미지 피커를 취소
+   */
+  async function takePhoto(): Promise<string | null> {
+    return handleImageAction(imagePickerLib.takePhoto);
+  }
+
+  return {
+    latestPath: state.latestPath,
+    loading: state.loading,
+    error: state.error,
+    pickImage,
+    takePhoto,
+  };
+};

--- a/src/modules/imagePicker/index.ts
+++ b/src/modules/imagePicker/index.ts
@@ -1,0 +1,1 @@
+export {useImagePicker} from './hook/use-image-picker';

--- a/src/modules/imagePicker/lib/image-picker.error.ts
+++ b/src/modules/imagePicker/lib/image-picker.error.ts
@@ -1,0 +1,67 @@
+import type {PickerErrorCode} from 'react-native-image-crop-picker';
+
+export type ImagePickerErrorCodeType =
+  | PickerErrorCode
+  | 'E_PATH_NOT_FOUND'
+  | 'E_UNKNOWN'
+  | 'E_UNEXPECTED';
+
+export enum ImagePickerErrorCode {
+  // react-native-image-crop-picker error code
+  E_PICKER_CANCELLED = 'E_PICKER_CANCELLED',
+  E_NO_IMAGE_DATA_FOUND = 'E_NO_IMAGE_DATA_FOUND',
+  E_NO_LIBRARY_PERMISSION = 'E_NO_LIBRARY_PERMISSION',
+  E_NO_CAMERA_PERMISSION = 'E_NO_CAMERA_PERMISSION',
+  E_ERROR_WHILE_CLEANING_FILES = 'E_ERROR_WHILE_CLEANING_FILES',
+  E_PICKER_CANNOT_RUN_CAMERA_ON_SIMULATOR = 'E_PICKER_CANNOT_RUN_CAMERA_ON_SIMULATOR',
+  E_CROPPER_IMAGE_NOT_FOUND = 'E_CROPPER_IMAGE_NOT_FOUND',
+  E_CANNOT_SAVE_IMAGE = 'E_CANNOT_SAVE_IMAGE',
+  E_CANNOT_PROCESS_VIDEO = 'E_CANNOT_PROCESS_VIDEO',
+  E_ACTIVITY_DOES_NOT_EXIST = 'E_ACTIVITY_DOES_NOT_EXIST',
+  E_CALLBACK_ERROR = 'E_CALLBACK_ERROR',
+  E_FAILED_TO_SHOW_PICKER = 'E_FAILED_TO_SHOW_PICKER',
+  E_FAILED_TO_OPEN_CAMERA = 'E_FAILED_TO_OPEN_CAMERA',
+  E_CAMERA_IS_NOT_AVAILABLE = 'E_CAMERA_IS_NOT_AVAILABLE',
+  E_CANNOT_LAUNCH_CAMERA = 'E_CANNOT_LAUNCH_CAMERA',
+
+  // custom error code
+  E_PATH_NOT_FOUND = 'E_PATH_NOT_FOUND',
+  E_UNKNOWN = 'E_UNKNOWN',
+  E_UNEXPECTED = 'E_UNEXPECTED',
+}
+
+export class ImagePickerError extends Error {
+  code: ImagePickerErrorCodeType;
+
+  constructor(message: string, code: ImagePickerErrorCodeType) {
+    super(message);
+    this.name = 'ImagePickerError';
+    this.code = code;
+  }
+
+  private static hasCode(error: Error): error is Error & {code: string} {
+    return Object.hasOwn(error, 'code');
+  }
+
+  public static throwError(error: unknown): never {
+    if (error instanceof ImagePickerError) {
+      throw error;
+    }
+    if (error instanceof Error) {
+      if (
+        this.hasCode(error) &&
+        error.code === ImagePickerErrorCode.E_PICKER_CANCELLED
+      ) {
+        throw new ImagePickerError(
+          error.message,
+          ImagePickerErrorCode.E_PICKER_CANCELLED,
+        );
+      }
+      throw new ImagePickerError(error.message, ImagePickerErrorCode.E_UNKNOWN);
+    }
+    throw new ImagePickerError(
+      error as string,
+      ImagePickerErrorCode.E_UNEXPECTED,
+    );
+  }
+}

--- a/src/modules/imagePicker/lib/image-picker.error.ts
+++ b/src/modules/imagePicker/lib/image-picker.error.ts
@@ -60,7 +60,7 @@ export class ImagePickerError extends Error {
       throw new ImagePickerError(error.message, ImagePickerErrorCode.E_UNKNOWN);
     }
     throw new ImagePickerError(
-      error as string,
+      String(error),
       ImagePickerErrorCode.E_UNEXPECTED,
     );
   }

--- a/src/modules/imagePicker/lib/image-picker.ts
+++ b/src/modules/imagePicker/lib/image-picker.ts
@@ -1,6 +1,7 @@
 import ImageCropPicker, {
   Image as CropImage,
 } from 'react-native-image-crop-picker';
+import {ImagePickerError, ImagePickerErrorCode} from './image-picker.error';
 
 export async function pickImage(): Promise<string> {
   try {
@@ -15,10 +16,16 @@ export async function pickImage(): Promise<string> {
       cropperCancelColor: '#999999',
     });
 
-    return image.path ?? '';
-  } catch (error: any) {
-    console.error('이미지 선택 실패:', error?.message);
-    return '';
+    if (!image || !image.path) {
+      throw new ImagePickerError(
+        '이미지 선택 실패',
+        ImagePickerErrorCode.E_PATH_NOT_FOUND,
+      );
+    }
+
+    return image.path;
+  } catch (error) {
+    ImagePickerError.throwError(error);
   }
 }
 
@@ -34,9 +41,15 @@ export async function takePhoto(cropping: boolean = true): Promise<string> {
       cropperCancelText: '취소',
     });
 
-    return image.path ?? '';
-  } catch (error: any) {
-    console.error('카메라 실행 실패', error?.message);
-    return '';
+    if (!image || !image.path) {
+      throw new ImagePickerError(
+        '카메라 선택 실패',
+        ImagePickerErrorCode.E_PATH_NOT_FOUND,
+      );
+    }
+
+    return image.path;
+  } catch (error) {
+    ImagePickerError.throwError(error);
   }
 }

--- a/src/navigation/DetailNavigator.tsx
+++ b/src/navigation/DetailNavigator.tsx
@@ -43,6 +43,7 @@ const orderDetailScreenOptions: StackNavigationOptions = {
 
 const reviewCreateScreenOptions: StackNavigationOptions = {
   ...screenOptions,
+  headerRight: () => null,
   headerTitle: () => <HeaderTitle title="리뷰 작성" />,
 };
 

--- a/src/screens/ReviewCreateScreen/index.tsx
+++ b/src/screens/ReviewCreateScreen/index.tsx
@@ -10,7 +10,7 @@ import {
   useCreateReviewMutation,
   useUploadReviewImageMutation,
 } from '@/apis/review';
-import {pickImage} from '@/utils/image-picker';
+import {useImagePicker} from '@/modules/imagePicker';
 import {
   Alert,
   Keyboard,
@@ -34,11 +34,11 @@ const ReviewCreateScreen = ({navigation, route}: ReviewCreateScreenProps) => {
   const {mutateAsync: reviewImageUploadMutate} = useUploadReviewImageMutation();
   const {mutate: reviewCreateMutate} = useCreateReviewMutation(orderId);
 
+  const {pickImage} = useImagePicker();
+
   const handleImageUpload = async () => {
     const res = await pickImage();
     if (!res) {
-      console.error('pickImage Error: no image');
-      Alert.alert('이미지를 불러오지 못했습니다.');
       return;
     }
     setReviewImageUris(prev => [...prev, res]);


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 개요

- utils/ 하위에는 순수함수만을 유지하고 외부 라이브러리를 래핑하는 모듈의 경우는 modules로 분리하는 구조로 제안합니다.
- utils/notification 등도 이와 같이 분리하면 좋겠습니다.

### ImagePicker

이미지 피커 사용시 사용자가 이미지를 선택하지 않고 종료하는 경우에도 에러를 던져 Alert 창이 나오는 것을 방지하기 위한 작업을 진행하였습니다.

### modules 하위 디렉토리 구조

- lib/ 
  - 외부 라이브러리를 래핑하는 기능함수 파일
  - type, error, const, enum 등의 상수와 타입선언 파일
- hook
  - 클라이언트에서 사용할 react 훅.
  - React hook, RN 내장 기능 등 클라이언트에서 사용하는 코드 사용
  - 외부 노출
- index.ts
  - 외부에 노출할 파일 선언
  - `{}`를 활용하여 이름 강제하는 것이 좋은 것 같습니다. `export {useImagePicker} from './hook/use-image-picker';` 형식
  - 필요시 lib/ 하위의 타입, 상수를 노출할 수도 있지만 hook에서 lib하위의 파일들은 모두 사용하고 클라이언트는 항상 hook에서 제공하는 함수와 변수만을 사용하는 구조면 좋을 것 같습니다.
  - \*  react hook을 사용할 필요가 없는 경우에는 어떤 모듈을 export하도록 설계할지 파일 구조에 대해서 고민을 해볼게요.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

### 안드로이드

해당 AndroidManifest.xml 설정에서 dev 실행은 되는데 release 빌드가 안되는 에러가 있습니다... 혹시 한번 같이 찾아주시면 압도적 감사

```xml
<service android:name="com.google.android.gms.metadata.ModuleDependencies" android:enabled="false" android:exported="false">
      <intent-filter>
        <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
      </intent-filter>
      <meta-data android:name="photopicker_activity:0:required" android:value="" />
    </service>
```
