### PR TITLE
build: 안드로이드 배포 명령어 변경

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,7 +79,13 @@ platform :android do
   lane :dev do
     sh "cp ../.env.development ../.env"
     Dotenv.load('.env') 
-    sh "cd ../android && ./gradlew clean installDebug"
+    sh "cd ../android && ./gradlew clean bundleRelease"
+
+      upload_to_play_store(
+      aab: "android/app/build/outputs/bundle/release/app-release.aab",
+      track: 'internal',
+      json_key: ENV["ANDROID_JSON_KEY_PATH_FASTFILE"]
+    )
   end
 
   desc "Build release aab and upload to internal track"
@@ -91,7 +97,7 @@ platform :android do
 
     upload_to_play_store(
       aab: "android/app/build/outputs/bundle/release/app-release.aab",
-      track: 'internal',
+      track: 'beta',
       json_key: ENV["ANDROID_JSON_KEY_PATH_FASTFILE"]
     )
   end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -59,7 +59,7 @@ bundle install
 ```
 
 ✅ 개발 서버용 `.env.development` 설정  
-✅ Debug 빌드 (`installDebug`) 후 기기에 설치
+✅ AAB 빌드 후 내부 트랙으로 업로드
 
 ---
 
@@ -70,9 +70,7 @@ bundle install
 ```
 
 🚀 프로덕션 서버용 `.env.release` 설정  
-🚀 AAB 빌드 (`bundleRelease`)  
-🚀 Play Store 내부 테스트 트랙 업로드  
-※ `android/service-account.json` 필요
+🚀 Play Store 베타 트랙으로 업로드  
 
 ---
 


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->

## 📝작업 내용

fastlane 안드로이드 명령어 역할 변경했습니다.
android develop은 디버그 빌드였는데, 이번 작업에서 aab 빌드 이후 내부 트랙으로 업로드로 변경,
android release는 베타 트랙으로 업로드로 변경하였습니다.

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
